### PR TITLE
Refactor: Flexible metadata store interface with in-memory and SQLite backends

### DIFF
--- a/docs/architecture/components/metadata-store-interface.md
+++ b/docs/architecture/components/metadata-store-interface.md
@@ -1,0 +1,71 @@
+# Metadata Store Interface
+
+## 1. Purpose and Scope
+
+Defines the abstraction contract for metadata storage backends. All backends (JSON, SQLite, RDF, SPARQL, etc.) must conform to this interface.
+
+## 2. Configuration and Runtime Selection
+
+- **Configuration Format:**  
+  - Backend type and configuration are specified in the processor config file (validated by Pydantic).
+  - Example:
+    ```toml
+    [metadata_store]
+    backend = "sqlite"
+    db_path = "knowledgebase.db"
+    ```
+- **Runtime Selection:**  
+  - The backend is selected at application startup based on configuration.
+  - Environment variables or CLI arguments may override config file settings.
+  - Dependency injection (constructor or DI framework) wires the selected backend.
+- **Validation:**  
+  - All configuration is validated before backend instantiation.
+  - Backends must declare supported configuration schema and interface version.
+
+## 3. Interface Contract
+
+- **Core Methods:**  
+  - `save(metadata: DocumentMetadata) -> str` (returns document_id)
+  - `get(document_id: str) -> Optional[DocumentMetadata]`
+  - `list_all() -> List[str]`
+  - `search(query: Dict[str, Any]) -> List[str]`
+  - `close() -> None`
+- **Type Signatures:**  
+  - Use Pydantic models for all metadata objects.
+- **Error Handling:**  
+  - All methods must raise custom exceptions for predictable failure modes.
+
+## 4. Plugin/Backend Registration
+
+- **Plugin Pattern:**  
+  - Each backend registers itself with a central registry using a unique backend type string.
+  - Discovery at runtime via entry points or registry.
+  - Factory for backend instantiation.
+
+## 5. Extensibility, Versioning, and Compliance
+
+- **Hooks:**  
+  - Allow pre/post-processing via overridable methods.
+- **Versioning:**  
+  - Interface and schema are versioned; backends must declare supported versions.
+- **Testing:**  
+  - All backends must pass an abstract test suite.
+
+## 6. Example Usage
+
+- Config-driven backend selection and instantiation.
+- Registering a new backend.
+
+## 7. Architecture Diagram
+
+```mermaid
+flowchart TD
+    A[Config File] --> B[Backend Selector]
+    B -->|Reads backend type| C[Backend Registry]
+    C -->|Instantiates| D1[SQLite Backend]
+    C -->|Instantiates| D2[JSON Backend]
+    C -->|Instantiates| D3[RDF/SPARQL Backend]
+    D1 -.->|Implements| E[MetadataStore Interface]
+    D2 -.->|Implements| E
+    D3 -.->|Implements| E
+    E --> F[Processor Core]

--- a/docs/architecture/decisions/0008-flexible-metadata-store.md
+++ b/docs/architecture/decisions/0008-flexible-metadata-store.md
@@ -1,0 +1,106 @@
+# ADR-0008: Flexible Metadata Store System
+
+**Date:** 2025-05-15
+
+**Status:** Proposed
+
+## Context
+
+The knowledge base processor requires a metadata store system that can adapt to diverse use cases and data models. Current limitations in metadata storage include a lack of flexibility to support various storage backends, such as JSON files, graph databases, RDF, or SPARQL endpoints. This inflexibility hinders the ability to meet evolving requirements, such as:
+
+- Storing hierarchical or graph-based relationships.
+- Supporting semantic queries using RDF or SPARQL.
+- Handling lightweight, file-based metadata storage for simpler use cases.
+
+The goal is to design a system that accommodates these diverse needs while maintaining extensibility and scalability.
+
+## Decision
+
+We will implement a flexible metadata store system that supports multiple storage backends, including but not limited to JSON, graph databases, RDF, and SPARQL. The system will use an abstraction layer to decouple the core logic from specific storage implementations, enabling seamless integration of new backends as needed.
+
+### Interface Contract
+
+A formal interface contract for the metadata store abstraction will be defined in [`docs/architecture/components/metadata-store-interface.md`](../components/metadata-store-interface.md). This contract will specify:
+- Required CRUD and query methods, with type signatures.
+- Error handling via custom exception classes and documented failure modes.
+- Extensibility points, such as hooks for pre/post-processing and support for backend-specific extensions.
+
+All backend implementations must conform to this interface. The interface will be versioned to support future evolution.
+
+### Backend Integration Mechanisms
+
+- **Plugin Pattern:** New backend implementations will be integrated using a plugin pattern. Each backend registers itself with a central registry at import time.
+- **Discovery:** The system will discover available backends via entry points or a registry mechanism, allowing dynamic loading.
+- **Registration:** Backend classes must register a unique backend type string and provide a factory for instantiation.
+- **Extensibility:** Adding a new backend requires implementing the interface and registering with the plugin system; no core code changes are needed.
+
+See the detailed specification in [`metadata-store-interface.md`](../components/metadata-store-interface.md).
+
+### Configuration Format and Runtime Selection
+
+- **Format:** The backend and its configuration will be specified in the configuration file used by the processor .
+- **Validation:** All configuration and schema validation will use Pydantic, as established in [ADR-0002](0002-pydantic-for-data-models.md). This ensures type safety, clear error reporting, and consistency across the system.
+- **Runtime Selection:** The backend type is selected at runtime based on the configuration. Environment variables or CLI arguments may override the config file for advanced use cases.
+
+### Dependency Injection Approach
+
+- **Pattern:** Constructor injection will be used to provide the selected metadata store implementation to system components.
+- **Framework:** The system may use a DI library such as [`dependency-injector`](https://python-dependency-injector.ets-labs.org/) for wiring dependencies, or a simple provider/factory pattern if requirements remain minimal.
+- **Wiring:** DI is configured at application startup, reading the configuration and instantiating the appropriate backend.
+
+### Schema Validation, Migration, Testing, and Versioning
+
+- **Schema Validation:** All metadata and configuration will be validated using Pydantic models before storage or use. Backend-specific validation may be layered as needed.
+- **Migration:** Schema versions will be tracked in metadata. Migration scripts or routines will be provided to upgrade data between versions.
+- **Testing:** An abstract test suite will be defined to verify all backend implementations for correctness and compliance. Each backend must pass these tests.
+- **Versioning:** The interface and data schema will be versioned. Backends must declare supported versions and handle migrations as needed.
+
+### Detailed Design Reference
+
+The full interface contract, backend plugin specification, and example implementations are documented in [`docs/architecture/components/metadata-store-interface.md`](../components/metadata-store-interface.md). This ADR will be updated to reference future changes in that document.
+
+## Rationale
+
+This decision aligns with the following principles:
+
+- **Extensibility:** By abstracting the storage layer, we can add support for new backends without modifying the core system.
+- **Scalability:** Different backends can be chosen based on the scale and complexity of the metadata, ensuring optimal performance.
+- **Flexibility:** Users can select the most appropriate storage backend for their specific use case, enhancing the system's adaptability.
+- **Consistency:** Using Pydantic for all validation and schema enforcement ensures a unified approach, as established in ADR-0002.
+
+Alternatives, such as committing to a single storage backend, were considered but rejected due to their inability to meet the diverse requirements outlined above.
+
+## Alternatives Considered
+
+1. **Single Backend Approach:**
+   - **Advantages:** Simplicity in implementation and maintenance.
+   - **Disadvantages:** Limited flexibility and scalability, making it unsuitable for diverse use cases.
+
+2. **Custom Storage Format:**
+   - **Advantages:** Tailored to specific needs of the knowledge base processor.
+   - **Disadvantages:** High development and maintenance costs, with limited interoperability.
+
+## Consequences
+
+### Positive Consequences
+
+- Enables support for a wide range of use cases, from simple file-based storage to complex semantic queries.
+- Future-proofs the system by allowing easy integration of emerging storage technologies.
+- Improves user satisfaction by offering customizable storage options.
+- Maintains consistency and reliability by standardizing on Pydantic for validation.
+
+### Negative Consequences
+
+- Increased complexity in the initial implementation due to the need for an abstraction layer.
+- Potential overhead in maintaining compatibility with multiple backends.
+
+## Related Decisions
+
+- ADR-0006: Consolidate Document Metadata Processing
+- ADR-0004: Package Structure
+- ADR-0002: Pydantic for Data Models
+
+## Notes
+
+- The detailed interface contract and backend plugin specification are maintained in [`docs/architecture/components/metadata-store-interface.md`](../components/metadata-store-interface.md).
+- This decision will require updates to the system's architecture documentation and testing framework to ensure compatibility with multiple backends.

--- a/src/knowledgebase_processor/main.py
+++ b/src/knowledgebase_processor/main.py
@@ -22,7 +22,7 @@ from .extractor.wikilink_extractor import WikiLinkExtractor
 from .analyzer.topics import TopicAnalyzer
 from .analyzer.entity_recognizer import EntityRecognizer # Corrected import
 from .enricher.relationships import RelationshipEnricher
-from .metadata_store.store import MetadataStore
+from .metadata_store.factory import get_metadata_store
 from .query_interface.query import QueryInterface
 from .models.content import Document
 from .models.metadata import DocumentMetadata
@@ -35,7 +35,7 @@ class KnowledgeBaseProcessor:
     and provides a simple interface for using them.
     """
     
-    def __init__(self, knowledge_base_dir: str, metadata_store_path: str):
+    def __init__(self, knowledge_base_dir: str, metadata_store_path: str, metadata_store_backend: str = "sqlite"):
         """Initialize the Knowledge Base Processor.
         
         Args:
@@ -49,7 +49,7 @@ class KnowledgeBaseProcessor:
         self.reader = Reader(knowledge_base_dir)
         self.processor = Processor()
         # MetadataStore now receives the full, resolved path to the DB file.
-        self.metadata_store = MetadataStore(db_path=metadata_store_path)
+        self.metadata_store = get_metadata_store(backend=metadata_store_backend, db_path=metadata_store_path)
         self.query_interface = QueryInterface(self.metadata_store)
         
         # Register extractors

--- a/src/knowledgebase_processor/metadata_store/__init__.py
+++ b/src/knowledgebase_processor/metadata_store/__init__.py
@@ -1,3 +1,4 @@
-"""Metadata store component for storing and retrieving metadata."""
-
-from .store import MetadataStore
+from .interface import MetadataStoreInterface
+from .inmemory import InMemoryMetadataStore
+from .store import SQLiteMetadataStore
+from .factory import get_metadata_store

--- a/src/knowledgebase_processor/metadata_store/factory.py
+++ b/src/knowledgebase_processor/metadata_store/factory.py
@@ -1,0 +1,19 @@
+from .inmemory import InMemoryMetadataStore
+from .store import SQLiteMetadataStore
+
+def get_metadata_store(backend: str = "sqlite", **kwargs):
+    """
+    Factory to get the appropriate metadata store backend.
+    Args:
+        backend: "sqlite" or "memory"
+        kwargs: parameters for backend constructors
+    Returns:
+        An instance of the selected metadata store.
+    """
+    if backend == "memory":
+        return InMemoryMetadataStore()
+    elif backend == "sqlite":
+        db_path = kwargs.get("db_path", "knowledgebase.db")
+        return SQLiteMetadataStore(db_path=db_path)
+    else:
+        raise ValueError(f"Unknown metadata store backend: {backend}")

--- a/src/knowledgebase_processor/metadata_store/inmemory.py
+++ b/src/knowledgebase_processor/metadata_store/inmemory.py
@@ -1,0 +1,30 @@
+from typing import List, Dict, Any, Optional
+from .interface import MetadataStoreInterface
+from ..models.metadata import DocumentMetadata
+
+class InMemoryMetadataStore(MetadataStoreInterface):
+    def __init__(self):
+        self._store: Dict[str, DocumentMetadata] = {}
+
+    def save(self, metadata: DocumentMetadata) -> None:
+        self._store[metadata.document_id] = metadata
+
+    def get(self, document_id: str) -> Optional[DocumentMetadata]:
+        return self._store.get(document_id)
+
+    def list_all(self) -> List[str]:
+        return list(self._store.keys())
+
+    def search(self, query: Dict[str, Any]) -> List[str]:
+        results = []
+        for doc_id, metadata in self._store.items():
+            if 'tags' in query and hasattr(metadata, 'tags'):
+                if query['tags'] in getattr(metadata, 'tags', []):
+                    results.append(doc_id)
+            elif 'title_contains' in query and hasattr(metadata, 'title'):
+                if query['title_contains'].lower() in (metadata.title or '').lower():
+                    results.append(doc_id)
+        return results
+
+    def close(self) -> None:
+        pass

--- a/src/knowledgebase_processor/metadata_store/interface.py
+++ b/src/knowledgebase_processor/metadata_store/interface.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+from ..models.metadata import DocumentMetadata
+
+class MetadataStoreInterface(ABC):
+    @abstractmethod
+    def save(self, metadata: DocumentMetadata) -> None:
+        """Save metadata to the store."""
+        pass
+
+    @abstractmethod
+    def get(self, document_id: str) -> Optional[DocumentMetadata]:
+        """Retrieve metadata for a document."""
+        pass
+
+    @abstractmethod
+    def list_all(self) -> List[str]:
+        """List all document IDs."""
+        pass
+
+    @abstractmethod
+    def search(self, query: Dict[str, Any]) -> List[str]:
+        """Search for documents matching the query."""
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the store and release resources."""
+        pass

--- a/src/knowledgebase_processor/metadata_store/store.py
+++ b/src/knowledgebase_processor/metadata_store/store.py
@@ -13,11 +13,13 @@ from ..models.links import Link, WikiLink
 logger = logging.getLogger(__name__)
 
 
-class MetadataStore:
+from .interface import MetadataStoreInterface
+
+class SQLiteMetadataStore(MetadataStoreInterface):
     """Store for document metadata using an SQLite database."""
 
     def __init__(self, db_path: str = "knowledgebase.db"):
-        """Initialize the MetadataStore and connect to the SQLite database.
+        """Initialize the SQLiteMetadataStore and connect to the SQLite database.
 
         Args:
             db_path: Path to the SQLite database file.
@@ -55,7 +57,7 @@ class MetadataStore:
                 # No further action like _create_tables() if connection failed.
 
         except RuntimeError as e: # Catch error from _connect()
-            logger.error(f"Failed to initialize MetadataStore due to connection error: {e}")
+            logger.error(f"Failed to initialize SQLiteMetadataStore due to connection error: {e}")
             # self.conn remains None, store is not operational.
 
     def _connect(self):

--- a/src/knowledgebase_processor/query_interface/query.py
+++ b/src/knowledgebase_processor/query_interface/query.py
@@ -2,7 +2,7 @@
 
 from typing import List, Dict, Any, Optional, Set
 
-from ..metadata_store.store import MetadataStore
+from ..metadata_store.interface import MetadataStoreInterface
 from ..models.content import Document
 from ..models.metadata import DocumentMetadata
 
@@ -14,7 +14,7 @@ class QueryInterface:
     based on various criteria.
     """
     
-    def __init__(self, metadata_store: MetadataStore):
+    def __init__(self, metadata_store: MetadataStoreInterface):
         """Initialize the QueryInterface.
         
         Args:


### PR DESCRIPTION
This PR implements a flexible metadata store interface as described in [ADR 0008](https://github.com/dstengle/knowledgebase-processor/blob/main/docs/architecture/decisions/0008-flexible-metadata-store.md) and [component doc](https://github.com/dstengle/knowledgebase-processor/blob/main/docs/architecture/components/metadata-store-interface.md). It adds:

- `MetadataStoreInterface` abstract base class
- `InMemoryMetadataStore` and `SQLiteMetadataStore` backends
- Factory for backend selection
- Updated usage throughout the codebase

Closes #26.