### PR TITLE
docs: Document architectural shift to knowledge graph/RDF

### DIFF
--- a/docs/architecture/decisions/0009-knowledge-graph-rdf-store.md
+++ b/docs/architecture/decisions/0009-knowledge-graph-rdf-store.md
@@ -1,0 +1,70 @@
+# ADR Template
+
+## ADR-0009: Knowledge Graph and RDF Store for Enhanced Knowledge Representation
+
+**Date:** 2025-05-18
+
+**Status:** Accepted
+
+## Context
+
+The current system relies on a document and metadata model, recently implemented with a SQLite-based metadata store. While functional for basic metadata and task extraction, this model presents limitations for more advanced knowledge representation and analysis. Specifically:
+- Adding new kinds of knowledge (e.g., diverse entity types, complex relationships) requires significant SQL schema changes, making the system rigid.
+- Performing relationship analysis beyond simple queries is difficult with the current structure.
+- The goal is to create a composite view of knowledge, allowing for rich inference while retaining connections to the original markdown data.
+- A more flexible approach is needed to represent various node types (meetings, people, books, topics, tasks) and their interconnections.
+
+## Decision
+
+We will adopt a knowledge graph approach using RDF (Resource Description Framework) and a triple/quad store for knowledge representation. The processing of markdown input will first create a document model, followed by document-level inference (e.g., topics, tags). Subsequently, typed nodes and relationships will be extracted from the document content and metadata to populate the knowledge graph.
+
+## Rationale
+
+This decision supports the project's goals for deeper knowledge analysis and extensibility:
+- **Enhanced Flexibility**: A graph model with typed nodes (e.g., `ex:Person`, `ex:Meeting`, `ex:Topic`) and defined relationships (e.g., `ex:attends`, `ex:discusses`) is inherently more flexible than a relational schema for representing diverse and evolving knowledge structures.
+- **Improved Querying and Inference**: RDF and SPARQL (the standard query language for RDF) allow for complex queries, pattern matching, and semantic inference that are difficult to achieve with SQL against the current model. This is crucial for relationship-based queries like "How do I know John Smith?" or "What tasks are related to Project Alpha meetings?".
+- **Extensibility**: Adding new types of entities or relationships in a graph model typically involves defining new RDF classes and properties, rather than altering a rigid database schema.
+- **Standardization**: RDF provides a W3C standard for data interchange on the Web, which can be beneficial for interoperability and leveraging existing tools and libraries.
+- **Alignment with Processing Pipeline**: The planned two-stage processing (document model -> graph model) allows for initial data enrichment at the document level before transforming relevant pieces into a more structured knowledge graph.
+
+This approach aligns with the architectural principle of "Iterative Enhancement" by providing a more robust foundation for future semantic and contextual analysis (Phase 2 and 3 of the roadmap).
+
+## Alternatives Considered
+
+1.  **Evolving the Existing SQLite Document/Metadata Model:**
+    *   **Description:** Continue using the SQLite store and incrementally add tables/columns to support new knowledge types and relationships.
+    *   **Advantages:** Builds on existing infrastructure and developer familiarity.
+    *   **Disadvantages:** Becomes increasingly complex and unwieldy as more diverse knowledge types and relationships are added. Schema evolution is cumbersome and error-prone. Limited capabilities for complex graph-like queries and inference.
+
+2.  **Using a Non-RDF Graph Database (e.g., Property Graph like Neo4j):**
+    *   **Description:** Employ a native graph database that uses a property graph model (nodes, relationships, properties on both).
+    *   **Advantages:** Can be simpler to set up for certain use cases, often with intuitive query languages (e.g., Cypher). Good performance for graph traversals.
+    *   **Disadvantages:** While powerful, property graphs lack the formal semantics and standardization of RDF. SPARQL offers more expressive power for certain types of semantic queries and inference. RDF's schema language (RDFS/OWL) provides richer vocabulary definition capabilities. For a system focused on inferring relationships from textual data and potentially integrating diverse datasets, RDF's semantic web foundations are a better fit.
+
+## Consequences
+
+-   **Positive:**
+    *   Significantly improved ability to represent and query complex relationships between entities.
+    *   Greater flexibility in adding new types of knowledge without major schema overhauls.
+    *   Clearer separation between the initial document processing stages and the structured knowledge representation.
+    *   Enables more sophisticated features like semantic search and automated inference.
+-   **Negative:**
+    *   Introduction of new technologies (RDF, SPARQL, triple/quad store) requires a learning curve.
+    *   Potential for increased complexity in the data pipeline initially.
+    *   Choice of a specific triple/quad store backend will be a subsequent decision with its own implications.
+    *   Performance considerations for very large knowledge graphs will need to be managed.
+-   **Trade-offs:**
+    *   Increased initial development effort and learning curve for the benefit of long-term flexibility, query power, and semantic richness.
+
+## Related Decisions
+
+-   This decision directly impacts and likely supersedes aspects of [`ADR-0008-flexible-metadata-store.md`](docs/architecture/decisions/0008-flexible-metadata-store.md), as the primary "queryable metadata" store will now be the RDF triple/quad store. The SQLite store might still be used for intermediate processing or caching, but not as the main analytical store.
+-   Future ADRs will be needed for:
+    *   Selection of a specific triple/quad store (e.g., Apache Jena, RDF4J, Oxigraph, etc.).
+    *   Choice of RDF serialization formats (e.g., Turtle, N-Quads, JSON-LD).
+    *   Definition of core ontologies/vocabularies.
+
+## Notes
+
+-   The processing pipeline will be: Raw Markdown -> Parsed Document Model -> Document-Level Inference (topics, tags, summaries) -> Extraction of Entities & Relationships -> RDF Triples/Quads -> Triple/Quad Store.
+-   This shift emphasizes that the system is a composite view, not a system of record for the original markdown, but it will maintain links (e.g., via URIs) back to the source documents or specific sections within them.

--- a/docs/architecture/knowledge-graph-architecture-plan.md
+++ b/docs/architecture/knowledge-graph-architecture-plan.md
@@ -1,0 +1,47 @@
+# Knowledge Graph Architecture Documentation Plan
+
+## Overview
+
+This document outlines the plan for documenting the architectural shift from a document/metadata model to a knowledge graph approach using RDF and a triple/quad store. The plan includes capturing the decision, updating architectural documentation, and reflecting the new data flow and system impacts.
+
+---
+
+## Documentation Steps
+
+1. **Create a new ADR**  
+   - Document the decision to move to a knowledge graph/RDF-based system.
+   - Include context, rationale, alternatives, and consequences.
+
+2. **Update System Architecture Documentation**  
+   - Update `data-flow.md` and system-overview docs.
+   - Add a "Document Inference" step after the Document Model, before entity/relationship extraction.
+   - Update or add Mermaid diagrams and revise data model sections to reflect node/edge/triple representations.
+
+3. **Update or Add Feature Specifications**  
+   - Knowledge graph extraction.
+   - RDF export.
+   - Querying via SPARQL or similar.
+
+4. **Update the Evolution Roadmap**  
+   - Mark this as a major architectural milestone.
+
+---
+
+## Revised Data Flow Diagram
+
+```mermaid
+flowchart LR
+    A[Markdown Document] --> B[Document Model]
+    B --> C[Document Inference (Topics/Tags)]
+    C --> D[Entity & Relationship Extraction]
+    D --> E[Typed Graph Nodes/Edges]
+    E --> F[RDF Triple/Quad Store]
+    F --> G[Graph Query Interface]
+```
+
+---
+
+## Notes
+
+- The "Document Inference" step enables extraction of topics and tags at the document level before entity and relationship extraction.
+- This plan ensures the rationale, impact, and technical details of the architectural shift are clearly documented and traceable across the system documentation.

--- a/docs/architecture/roadmap/evolution-plan.md
+++ b/docs/architecture/roadmap/evolution-plan.md
@@ -2,201 +2,160 @@
 
 ## Revision History
 
-| Version | Date       | Author | Changes                              |
-|---------|------------|--------|--------------------------------------|
-| 0.1     | YYYY-MM-DD | [Name] | Initial draft                        |
+| Version | Date       | Author        | Changes                                                                          |
+|---------|------------|---------------|----------------------------------------------------------------------------------|
+| 0.2     | 2025-05-18 | Roo (AI Asst) | Aligned roadmap with Knowledge Graph/RDF architecture (ADR-0009). Updated phases, features, and metrics. |
+| 0.1     | YYYY-MM-DD | [Name]        | Initial draft                                                                    |
 
 ## Overview
 
-This document outlines the planned evolution of the Knowledge Base Processor system. It provides a roadmap for incremental development, focusing on delivering value at each stage while maintaining alignment with the architectural principles.
+This document outlines the planned evolution of the Knowledge Base Processor system. It provides a roadmap for incremental development, focusing on delivering value at each stage while maintaining alignment with the architectural principles, particularly the shift towards an RDF-based knowledge graph as detailed in [ADR-0009](../decisions/0009-knowledge-graph-rdf-store.md).
 
 ## Core Use Cases
 
-The development and prioritization of features in this evolution plan are significantly guided by a set of core use cases and target questions the system aims to address. These are detailed in the [Core Use Cases and Desired Outcomes document](../use-cases.md). Refer to that document for specific examples of questions the system should help answer and the types of insights it should provide.
+The development and prioritization of features in this evolution plan are significantly guided by a set of core use cases and target questions the system aims to address. These are detailed in the [Core Use Cases and Desired Outcomes document](../use-cases.md). The RDF knowledge graph is intended to provide a powerful backend for addressing these use cases.
 
-## Expanded Concept of Metadata
+## Expanded Concept of Knowledge Representation (RDF Focus)
 
-In this system, "metadata" encompasses all aspects of the knowledge base content:
+With the shift to RDF, "knowledge" is represented as a graph of interconnected resources:
+1.  **Document Structure as RDF**: Headings, sections, lists become part of the graph, linked to their source.
+2.  **Explicit Metadata as RDF Properties**: Tags, categories, dates, frontmatter become RDF properties of document or entity resources.
+3.  **Content Elements as RDF**: Key content snippets, quotes, and todo items can be represented as resources or literals within the graph.
+4.  **Relationships as RDF Predicates**: Links, mentions, and conceptual connections (e.g., `meeting:discussesTopic`) become explicit RDF predicates.
+5.  **Semantic Entities as RDF Resources**: Topics, persons, organizations, projects, meetings are first-class citizens (typed resources) in the graph.
+6.  **Context via Graph Structure**: Proximity, co-occurrence, and provenance (e.g., source document for a triple) are modeled within the graph structure or using quads.
 
-1. **Traditional Metadata**: Tags, categories, dates, frontmatter
-2. **Structural Metadata**: Headings, sections, lists, tables, code blocks, todo items
-3. **Content Metadata**: Text content, quotes, emphasized text
-4. **Relational Metadata**: Links, references, mentions, citations
-5. **Semantic Metadata**: Topics, entities, concepts, themes
-6. **Contextual Metadata**: Position, proximity, co-occurrence
-
-The goal is to transform the entire knowledge base content into a rich, structured representation that preserves and enhances all aspects of the original content.
+The goal is to transform the knowledge base content into a rich, queryable RDF knowledge graph.
 
 ## Development Phases
 
-### Phase 1: Structural & Content Extraction
+### Phase 1: Foundational Knowledge Graph & Core Extraction
 
-**Focus**: Extract comprehensive structural and content elements from markdown.
+**Focus**: Establish the basic RDF infrastructure, parse Markdown, and extract core structural elements and explicit metadata into an initial RDF graph. Todo item extraction is a key deliverable.
 
 **Goals**:
-- Set up the basic system architecture
-- Implement the Reader component for accessing the knowledge base
-- Extract document structure (headings, sections, lists, tables)
-- Identify and extract todo items with their status and context
-- Parse and extract traditional metadata (frontmatter, tags)
-- Identify and extract links, references, and citations
-- Preserve the full content within a structured representation
+- Set up the basic RDF triple/quad store.
+- Define an initial RDF vocabulary/ontology for core concepts (documents, sections, persons, tasks, basic relationships).
+- Implement Reader & Parser for Markdown to Parsed Document Model.
+- Extract document structure (headings, sections), frontmatter, and explicit tags into RDF.
+- Identify and extract todo items with their status and context, representing them as RDF resources with appropriate properties.
+- Extract basic links and references, representing them as RDF relationships.
+- Ensure the Parsed Document Model is robust for subsequent, more detailed analysis.
 
 **Success Criteria**:
-- System can read from the knowledge base
-- All structural elements are correctly identified and extracted
-- Todo items are captured with their status and context
-- Content is preserved within its structural context
-- Links and references are captured with their context
+- System can read Markdown and produce a Parsed Document Model.
+- An RDF store is operational and can be populated.
+- Basic document structure, frontmatter, and tags are represented in the RDF graph.
+- Todo items are correctly extracted and represented as queryable RDF resources with status and textual content.
+- Simple SPARQL queries can retrieve documents, their sections, and associated todo items.
 
 **Timeframe**: [Estimated timeframe]
 
-### Phase 2: Semantic & Contextual Analysis
+### Phase 2: Semantic Enrichment & Deeper Graph Modeling
 
-**Focus**: Derive semantic meaning and contextual relationships from the extracted content.
+**Focus**: Enhance the RDF graph with richer semantic information through document-level inference and more detailed entity/relationship extraction.
 
 **Goals**:
-- Identify topics, entities, and concepts within the content
-- Analyze the context of structural elements including todo items
-- Establish relationships between content elements
-- Derive hierarchical and network structures
-- Generate semantic metadata that enhances understanding
-- Analyze todo items for patterns, dependencies, and priorities
+- Implement Analyzer for document-level inference (topics, inferred tags, summaries) from the Parsed Document Model, adding this information to the RDF graph.
+- Implement Extractor for detailed entity recognition (persons, organizations, projects, meetings) and relationship extraction (e.g., person attends meeting, document mentions project), populating the RDF graph.
+- Refine and expand the RDF vocabulary/ontology to support these new entities and relationships.
+- Model contextual information (e.g., source of a statement using quads/named graphs).
+- Analyze todo items within their graph context (e.g., linked projects, mentioned people).
 
 **Success Criteria**:
-- Entities and topics are accurately identified
-- Contextual relationships are established
-- Todo items are analyzed for patterns and relationships
-- Semantic metadata adds value beyond the explicit structure
-- The knowledge base structure is represented as both hierarchy and network
-- The analysis provides foundational data to support answering questions outlined in the [Core Use Cases document](../use-cases.md).
+- The RDF graph contains typed entities (persons, meetings, topics) linked by meaningful relationships.
+- Document-level inferences (topics, tags) are attached to document resources in the graph.
+- Todo items are linked to relevant entities (e.g., projects, people mentioned in the task).
+- SPARQL queries can retrieve information based on semantic relationships (e.g., "find all meetings discussing Topic X attended by Person Y").
 
 **Timeframe**: [Estimated timeframe]
 
-### Phase 3: Integration & Representation
+### Phase 3: Advanced Querying, Integration & Representation
 
-**Focus**: Create useful representations and integrations of the processed knowledge.
+**Focus**: Leverage the rich RDF knowledge graph through advanced SPARQL querying, develop useful representations, and enable integrations.
 
 **Goals**:
-- Develop methods to query the processed knowledge
-- Create visualizations of different aspects of the knowledge structure
-- Establish ways to navigate the knowledge base using the enhanced structure
-- Enable integration with other tools and workflows
-- Provide specialized views for todo items and task management
+- Develop a comprehensive suite of SPARQL queries to address the [Core Use Cases](../use-cases.md).
+- Implement a robust Graph Query Interface (SPARQL endpoint).
+- Create specialized views and dashboards, particularly for todo items and task management, powered by SPARQL queries.
+- Explore RDF graph visualization techniques.
+- Enable integration with external tools by exposing query capabilities or RDF data.
 
 **Success Criteria**:
-- The processed knowledge can be effectively queried
-- Visualizations provide insights not obvious in the original format
-- Todo items can be viewed and managed across the knowledge base
-- Navigation using the enhanced structure is intuitive and valuable
-- Integration with at least one external tool is demonstrated
-- The system can effectively answer a significant portion of the target questions defined in the [Core Use Cases document](../use-cases.md).
+- A significant portion of the target questions from the Core Use Cases can be answered via SPARQL queries.
+- Todo items can be effectively viewed, filtered, and managed across the knowledge base using graph-derived views.
+- The knowledge graph structure provides intuitive navigation and discovery paths.
+- At least one meaningful integration with an external tool or workflow is demonstrated.
 
 **Timeframe**: [Estimated timeframe]
 
-### Phase 4: Refinement & Extension
+### Phase 4: Refinement, Optimization & Extension
 
-**Focus**: Refine the system based on usage and extend its capabilities.
+**Focus**: Refine the system based on usage, optimize performance, and extend capabilities, including the ontology and query patterns.
 
 **Goals**:
-- Optimize processing based on user feedback
-- Add advanced analysis capabilities
-- Extend to additional content types if needed
-- Enhance todo item tracking and management
-- Ensure long-term maintainability
+- Optimize SPARQL query performance and RDF store efficiency.
+- Refine and expand the RDF ontology based on emergent patterns and user needs.
+- Add advanced analytical capabilities using graph algorithms or RDF inferencing (e.g., RDFS/OWL reasoning).
+- Enhance todo item tracking with more sophisticated status models or dependencies within the graph.
+- Ensure long-term maintainability of the RDF model and processing pipeline.
 
 **Success Criteria**:
-- System performs well with the user's full knowledge base
-- Advanced features provide additional value
-- Todo management features enhance productivity
-- System is stable and maintainable
+- System performs well with the user's full knowledge base.
+- Advanced graph features (e.g., inference, pathfinding) provide additional value.
+- Todo management features are robust and enhance productivity.
+- The RDF model is well-documented and maintainable.
 
 **Timeframe**: [Estimated timeframe]
 
 ## Feature Roadmap
 
-The following table outlines specific features planned for each phase:
-
-| Feature | Phase | Priority | Status | Dependencies |
-|---------|-------|----------|--------|--------------|
-| Markdown Structure Parser | 1 | High | Planned | None |
-| Heading & Section Extraction | 1 | High | Planned | Structure Parser |
-| List & Table Extraction | 1 | High | Planned | Structure Parser |
-| **Todo Item Extraction** | 1 | High | Planned | Structure Parser |
-| Code Block & Quote Extraction | 1 | High | Planned | Structure Parser |
-| Frontmatter & Tag Extraction | 1 | High | Planned | Structure Parser |
-| Link & Reference Extraction | 1 | High | Planned | Structure Parser |
-| Content Preservation | 1 | High | Planned | All Extraction Features |
-| Entity Recognition | 2 | High | Planned | Content Preservation |
-| Topic Identification | 2 | High | Planned | Content Preservation |
-| Contextual Analysis | 2 | High | Planned | Entity & Topic Features |
-| Relationship Mapping | 2 | High | Planned | Link Extraction |
-| **Todo Item Analysis** | 2 | High | Planned | Todo Item Extraction |
-| Hierarchical Structure Analysis | 2 | Medium | Planned | Heading Extraction |
-| Network Structure Analysis | 2 | Medium | Planned | Relationship Mapping |
-| Semantic Enrichment | 2 | Medium | Planned | Contextual Analysis |
-| Query Interface | 3 | High | Planned | Phase 2 Features |
-| Structure Visualization | 3 | High | Planned | Hierarchical & Network Analysis |
-| **Todo Management View** | 3 | High | Planned | Todo Item Analysis |
-| Enhanced Navigation | 3 | Medium | Planned | Query Interface |
-| External Tool Integration | 3 | Medium | Planned | Query Interface |
-| Performance Optimization | 4 | High | Planned | All Core Features |
-| Advanced Semantic Analysis | 4 | Medium | Planned | Semantic Enrichment |
-| **Advanced Todo Tracking** | 4 | Medium | Planned | Todo Management View |
-| Multi-format Support | 4 | Low | Planned | Core Extraction Features |
+| Feature                                         | Phase | Priority | Status  | Dependencies                                       | Notes (RDF Context)                                     |
+|-------------------------------------------------|-------|----------|---------|----------------------------------------------------|---------------------------------------------------------|
+| Markdown Parser to Document Model               | 1     | High     | Planned | None                                               | Foundation for all RDF generation                       |
+| Initial RDF Vocabulary/Ontology Definition      | 1     | High     | Planned | None                                               | Core classes (Document, Section, Task) & properties     |
+| RDF Store Setup & Integration                   | 1     | High     | Planned | None                                               | Choose and integrate a triple/quad store                |
+| Heading & Section Extraction to RDF             | 1     | High     | Planned | Parser, RDF Vocab                                  | `kb:Document hasSection kb:SectionX`                    |
+| Frontmatter & Explicit Tag Extraction to RDF    | 1     | High     | Planned | Parser, RDF Vocab                                  | `kb:Document dcterms:title "X"; dcterms:subject "tagY"` |
+| **Todo Item Extraction to RDF**                 | 1     | High     | Planned | Parser, RDF Vocab                                  | `kb:TaskX a kb:ToDoItem; dcterms:title "..."; kb:hasStatus kb:StatusOpen` |
+| Basic Link & Reference Extraction to RDF        | 1     | Medium   | Planned | Parser, RDF Vocab                                  | `kb:DocumentA dcterms:references kb:DocumentB`          |
+| Document-Level Inference (Topics, Tags) to RDF  | 2     | High     | Planned | Parser, RDF Vocab, Analyzer Component              | `kb:DocumentA kb:hasTopic kb:TopicZ`                    |
+| Entity Recognition (Person, Org, Project) to RDF| 2     | High     | Planned | Enriched Doc Model, RDF Vocab, Extractor Component | `kb:PersonX a foaf:Person; foaf:name "J. Doe"`          |
+| Relationship Extraction to RDF                  | 2     | High     | Planned | Entity Reco., RDF Vocab, Extractor Component       | `kb:PersonX kb:attends kb:MeetingY`                     |
+| **Todo Item Contextual Linking in RDF**         | 2     | High     | Planned | Todo RDF, Entity RDF                               | `kb:TaskX kb:relatedToProject kb:ProjectAlpha`          |
+| Advanced RDF Vocabulary/Ontology Expansion      | 2     | Medium   | Planned | Initial RDF Vocab, Phase 2 Learnings               | More specific relationships, classes                    |
+| SPARQL Endpoint Implementation                  | 3     | High     | Planned | RDF Store, Phase 2 Graph Data                      | Core query capability                                   |
+| SPARQL Queries for Core Use Cases               | 3     | High     | Planned | SPARQL Endpoint, Rich Graph                        | Answering user questions                                |
+| **Todo Management View (SPARQL-driven)**        | 3     | High     | Planned | SPARQL Queries, Todo RDF                           | Centralized task overview                               |
+| RDF Graph Visualization (Exploratory)           | 3     | Medium   | Planned | SPARQL Endpoint / RDF Store Access                 | Understanding graph structure                           |
+| External Tool Integration via SPARQL/RDF        | 3     | Medium   | Planned | SPARQL Endpoint                                    | Exporting/linking knowledge                             |
+| Performance Optimization (Store & Queries)      | 4     | High     | Planned | Populated Graph, Usage Patterns                    | Scalability and responsiveness                          |
+| RDF Inferencing (RDFS/OWL Basics)               | 4     | Medium   | Planned | Stable Ontology, RDF Store with Inf. Support       | Deriving new knowledge                                  |
+| **Advanced Todo Tracking in RDF**               | 4     | Medium   | Planned | Todo View, Ontology                                | Dependencies, sub-tasks in graph                        |
+| Ontology Refinement & Documentation             | 4     | High     | Planned | Usage Feedback                                     | Maintainability, clarity                                |
 
 ## Technical Debt Management
-
-To ensure the system remains maintainable throughout its evolution:
-
-1. **Regular Refactoring**:
-   - Schedule regular refactoring sessions after each phase
-   - Address technical debt before moving to new features
-
-2. **Documentation Updates**:
-   - Keep architecture documentation in sync with implementation
-   - Update ADRs as decisions evolve
-
-3. **Testing Strategy**:
-   - Maintain comprehensive tests for extraction and analysis logic
-   - Add tests for new features before implementation
+(As previously stated, with emphasis on RDF model and ontology documentation)
 
 ## Adaptation Strategy
-
-This roadmap is intended to be flexible and adaptable:
-
-1. **Regular Reviews**:
-   - Review the roadmap after each phase
-   - Adjust priorities based on actual usage and feedback
-
-2. **Feedback Integration**:
-   - Incorporate user feedback into feature prioritization
-   - Be willing to adjust the roadmap based on emerging needs
-
-3. **Scope Management**:
-   - Focus on delivering value rather than adhering strictly to the plan
-   - Be willing to defer or eliminate features that don't provide sufficient value
+(As previously stated, feedback will inform ontology evolution and SPARQL query development)
 
 ## Success Metrics
 
-The overall success of the system evolution will be measured by:
+1.  **Knowledge Graph Fidelity & Richness**:
+    *   How accurately and comprehensively does the RDF graph represent the structure, content, and semantics of the knowledge base?
+    *   Are todo items correctly modeled in RDF with their status, context, and relevant links (e.g., to projects, people)?
+    *   Does the ontology effectively capture the key concepts and relationships?
 
-1. **Structural Fidelity**:
-   - How accurately does the system capture the structure of the knowledge base?
-   - Are todo items properly extracted with their status and context?
-   - Is the full richness of the content preserved?
+2.  **Querying & Inferential Power**:
+    *   Can SPARQL queries effectively retrieve complex information and answer the target questions from the [Core Use Cases document](../use-cases.md)?
+    *   Does the graph structure (and any basic inferencing) reveal connections and insights not obvious in the original format?
+    *   Is todo management enhanced by the ability to query and relate tasks within the graph?
 
-2. **Semantic Enhancement**:
-   - Does the system derive meaningful semantic metadata?
-   - Does it reveal connections and insights not obvious in the original format?
-   - Does it help manage and prioritize todo items across the knowledge base?
+3.  **Practical Utility & Integration**:
+    *   Does the RDF knowledge graph enable more effective use and navigation of the knowledge base?
+    *   Do SPARQL-driven views (especially for todo items) improve task management?
+    *   Can the RDF data be integrated with or exported for use in other tools?
 
-3. **Practical Utility**:
-   - Does the processed knowledge enable more effective use of the knowledge base?
-   - Does it improve task management and todo tracking?
-   - Does it integrate well with existing workflows?
-   - Does it effectively answer the key questions outlined in the [Core Use Cases document](../use-cases.md)?
-
-4. **Personal Value**:
-   - Does it provide sufficient value to justify its existence?
-   - Does it make personal knowledge management more effective by addressing the scenarios in the [Core Use Cases document](../use-cases.md)?
+4.  **Personal Value**:
+    *   Does the system, with its RDF backend, provide significant value in managing personal knowledge and tasks?

--- a/docs/architecture/system-overview/components-update-plan.md
+++ b/docs/architecture/system-overview/components-update-plan.md
@@ -1,0 +1,74 @@
+# Plan to Update `components.md` for Pipeline and Orchestrator Clarification
+
+## 1. Clarify Orchestrator Role
+
+- Update the Orchestrator section to emphasize its role as the pipeline manager, not just a stage.
+- Adjust the Mermaid diagram so the Orchestrator is visually shown as managing the pipeline, not as a peer stage.
+
+## 2. Clarify Pipeline Structure
+
+- Revise the Mermaid diagram to show the Orchestrator as an overarching controller.
+- Add a brief explanatory section on pipeline orchestration and flow.
+
+## 3. Update Extractor Description
+
+- Change the Extractor’s purpose and responsibilities to focus on NLP and structural entity extraction only.
+- Remove or move relationship extraction to another component if needed.
+
+## 4. Explicit Entities as Python Objects
+
+- Add a note in the Extractor or a new “Design Considerations” subsection stating that explicit entities should be modeled as Python objects where possible.
+
+## 5. Diagram Update
+
+- Update the Mermaid diagram to reflect the above changes, showing the Orchestrator as the pipeline manager and clarifying the Extractor’s role.
+
+---
+
+## Example (Mermaid) Diagram Update
+
+```mermaid
+flowchart TD
+    subgraph "Input/Output"
+        KB[(Knowledge Base)]
+        Tools[Tools & Integrations]
+    end
+
+    subgraph "Processing Pipeline"
+        Reader["Reader & Parser"]
+        Analyzer["Analyzer (Document-Level Inference)"]
+        Extractor["Extractor (NLP & Structural Entity Extraction)"]
+        RDFConverter["RDF Conversion & Serialization"]
+        RDFStore["RDF Triple/Quad Store"]
+        QueryInterface["Graph Query Interface (SPARQL)"]
+    end
+
+    KB --> Reader
+    Reader --> Analyzer
+    Analyzer --> Extractor
+    Extractor --> RDFConverter
+    RDFConverter --> RDFStore
+    RDFStore --> QueryInterface
+    QueryInterface --> Tools
+
+    Orchestrator -.-> Reader
+    Orchestrator -.-> Analyzer
+    Orchestrator -.-> Extractor
+    Orchestrator -.-> RDFConverter
+    Orchestrator -.-> RDFStore
+    Orchestrator -.-> QueryInterface
+
+    classDef orchestrator fill:#ffe4b5,stroke:#333,stroke-width:2px;
+    class Orchestrator orchestrator;
+```
+
+---
+
+## Section-by-Section Update Plan
+
+- **Overview:** Add a sentence about the Orchestrator managing the pipeline.
+- **Component Diagram:** Update diagram and legend.
+- **Orchestrator Section:** Emphasize end-to-end management.
+- **Extractor Section:** Focus on entity extraction (NLP/structural), not relationships.
+- **Component Interactions:** Clarify Orchestrator’s role as coordinator.
+- **Design Considerations:** Add note about explicit entities as Python objects.

--- a/docs/architecture/system-overview/components.md
+++ b/docs/architecture/system-overview/components.md
@@ -2,185 +2,188 @@
 
 ## Revision History
 
-| Version | Date       | Author | Changes                              |
-|---------|------------|--------|--------------------------------------|
-| 0.1     | YYYY-MM-DD | [Name] | Initial draft                        |
+| Version | Date       | Author        | Changes                                                                 |
+|---------|------------|---------------|-------------------------------------------------------------------------|
+| 0.2     | 2025-05-18 | Roo (AI Asst) | Updated components for Knowledge Graph/RDF architecture as per ADR-0009. |
+| 0.1     | YYYY-MM-DD | [Name]        | Initial draft                                                           |
 
 ## Overview
 
-The Knowledge Base Processor is composed of several logical components that work together to extract, process, and store metadata from a personal knowledge base. This document outlines these components and their relationships.
+The Knowledge Base Processor is composed of several logical components that work together to read, parse, analyze, and transform content from a personal knowledge base into a queryable RDF knowledge graph. This document outlines these components and their relationships, reflecting the architecture described in [ADR-0009](../decisions/0009-knowledge-graph-rdf-store.md).
 
 ## Component Diagram
 
 ```mermaid
 graph TD
-    KB[Knowledge Base] --> Reader
+    subgraph "Input/Output"
+        KB[(Knowledge Base)]
+        Tools[Tools & Integrations]
+    end
+
+    subgraph "Processing Pipeline"
+        Reader["Reader & Parser"]
+        Processor[Orchestrator]
+        Analyzer["Analyzer (Document-Level Inference)"]
+        Extractor["Extractor (Entity & Relationship Extraction)"]
+        RDFConverter["RDF Conversion & Serialization"]
+        RDFStore["RDF Triple/Quad Store"]
+        QueryInterface["Graph Query Interface (SPARQL)"]
+    end
+
+    KB --> Reader
     Reader --> Processor
-    Processor --> Extractor
-    Processor --> Analyzer
-    Processor --> Enricher
-    Extractor --> MetadataStore
-    Analyzer --> MetadataStore
-    Enricher --> MetadataStore
-    MetadataStore --> QueryInterface
-    QueryInterface --> Tools[Tools & Integrations]
+    Processor -- Parsed Document Model --> Analyzer
+    Analyzer -- Enriched Document Model --> Extractor
+    Extractor -- Entities & Relationships --> RDFConverter
+    RDFConverter -- RDF Triples/Quads --> RDFStore
+    RDFStore --> QueryInterface
+    QueryInterface --> Tools
     
-    classDef core fill:#f9f,stroke:#333,stroke-width:2px;
-    classDef external fill:#bbf,stroke:#333,stroke-width:1px;
+    classDef core fill:#cdeccd,stroke:#333,stroke-width:2px;
+    classDef storage fill:#e2d6ff,stroke:#333,stroke-width:2px;
+    classDef external fill:#f5f5f5,stroke:#333,stroke-width:1px;
     
-    class Reader,Processor,Extractor,Analyzer,Enricher,MetadataStore,QueryInterface core;
+    class Reader,Processor,Analyzer,Extractor,RDFConverter,QueryInterface core;
+    class RDFStore storage;
     class KB,Tools external;
 ```
 
 ## Core Components
 
-### 1. Reader
+### 1. Reader & Parser (Previously Reader)
 
-**Purpose**: Reads content from the knowledge base in its native format.
-
-**Responsibilities**:
-- Access the knowledge base in a read-only manner
-- Parse different content formats (Markdown, text, etc.)
-- Provide a consistent interface for downstream components
-- Track which content has been processed
-
-**Interfaces**:
-- Input: Knowledge base location/access method
-- Output: Normalized content objects
-
-### 2. Processor
-
-**Purpose**: Orchestrates the metadata extraction and processing workflow.
+**Purpose**: Reads content from the knowledge base (Markdown files) and parses it into a structured internal representation.
 
 **Responsibilities**:
-- Coordinate the overall processing flow
-- Determine which extractors, analyzers, and enrichers to apply
-- Handle processing errors and retries
-- Manage processing state
+- Access the knowledge base files.
+- Parse Markdown syntax (frontmatter, headings, paragraphs, links, code blocks, etc.).
+- Create a "Parsed Document Model" – a structured object representing the document's content and explicit metadata.
+- Track which content has been processed.
 
 **Interfaces**:
-- Input: Normalized content from Reader
-- Output: Directs content to appropriate sub-components
+- Input: Knowledge base location (file paths).
+- Output: Parsed Document Model objects.
 
-### 3. Extractor
+### 2. Orchestrator (Previously Processor)
 
-**Purpose**: Extracts explicit metadata from content.
+**Purpose**: Orchestrates the overall data processing workflow from document parsing to RDF graph population.
 
 **Responsibilities**:
-- Extract frontmatter, tags, and other explicit metadata
-- Parse structured elements (tables, lists, etc.)
-- Identify references and links
-- Extract dates, titles, and other basic metadata
+- Coordinate the flow of data through Analyzer, Extractor, and RDFConverter components.
+- Manage the sequence of operations for each document.
+- Handle processing errors and logging.
 
 **Interfaces**:
-- Input: Content from Processor
-- Output: Explicit metadata
+- Input: Parsed Document Model from Reader & Parser.
+- Output: Directs data to subsequent components (Analyzer, Extractor).
 
-### 4. Analyzer
+### 3. Analyzer (Document-Level Inference)
 
-**Purpose**: Derives implicit metadata through content analysis.
+**Purpose**: Performs analysis on the Parsed Document Model to infer document-wide attributes and enrich the model.
 
 **Responsibilities**:
-- Identify topics and themes
-- Extract entities (people, places, concepts)
-- Determine content categories
-- Calculate relevance scores for extracted metadata
-- Perform analysis to support answering questions and deriving information as outlined in the [Core Use Cases document](../../use-cases.md) (e.g., concept inference, synonym detection).
+- Identify main topics or themes of the document.
+- Generate or suggest relevant tags/keywords.
+- Potentially create document summaries.
+- This stage enriches the Parsed Document Model before specific entities and relationships are extracted for the graph.
 
 **Interfaces**:
-- Input: Content from Processor
-- Output: Derived metadata
+- Input: Parsed Document Model from Orchestrator.
+- Output: Enriched Document Model (with inferred topics, tags, etc.).
 
-### 5. Enricher
+### 4. Extractor (Entity & Relationship Extraction)
 
-**Purpose**: Enhances metadata with additional context and relationships.
+**Purpose**: Identifies and extracts specific entities and the relationships between them from the Enriched Document Model.
 
 **Responsibilities**:
-- Connect related content items
-- Establish hierarchical relationships
-- Enhance metadata with additional context
-- Generate summaries or abstracts
-- Establish and model relationships (e.g., "employee of", "organization is part of") needed to support the [Core Use Cases document](../../use-cases.md).
-- Suggest placeholder links or content aggregations as per the use cases.
+- Recognize named entities (People, Organizations, Locations, Dates, Projects, Meetings, Concepts like "ToDo Item") and assign them types.
+- Identify relationships between these entities (e.g., "Person A *attends* Meeting X", "Document Z *mentions* Topic Y").
+- Utilize both explicit information (e.g., from frontmatter, wikilinks) and context from the document content.
 
 **Interfaces**:
-- Input: Content and metadata from Processor
-- Output: Enhanced metadata
+- Input: Enriched Document Model from Analyzer.
+- Output: A structured list of identified entities and relationships.
 
-### 6. Metadata Store
+### 5. RDF Conversion & Serialization (New Component)
 
-**Purpose**: Stores and manages extracted metadata.
+**Purpose**: Transforms the extracted entities and relationships into RDF triples or quads.
 
 **Responsibilities**:
-- Store metadata in a queryable format
-- Maintain relationships between content and metadata
-- Support efficient retrieval patterns
-- Ensure metadata integrity
+- Map entities to RDF resources (assigning URIs).
+- Map entity types to RDF classes (e.g., `foaf:Person`, `kb:Meeting`).
+- Map entity attributes to RDF properties (e.g., `foaf:name`, `dcterms:title`).
+- Map relationships to RDF predicates (e.g., `kb:attends`, `kb:discussesTopic`).
+- Serialize the RDF data into a standard format (e.g., Turtle, N-Quads, JSON-LD).
+- Potentially assign triples/quads to named graphs (e.g., based on source document URI for provenance).
 
 **Interfaces**:
-- Input: Metadata from Extractors, Analyzers, and Enrichers
-- Output: Stored metadata accessible via Query Interface
+- Input: Structured list of entities and relationships from Extractor.
+- Output: RDF data (e.g., a stream of triples/quads or a serialized RDF document).
 
-### 7. Query Interface
+### 6. RDF Triple/Quad Store (Previously Metadata Store)
 
-**Purpose**: Provides access to stored metadata.
+**Purpose**: Stores, manages, and indexes the generated RDF data, forming the knowledge graph.
 
 **Responsibilities**:
-- Support queries for different metadata types
-- Enable filtering and sorting
-- Provide integration points for external tools
-- Support both programmatic and user-friendly access
-- Enable queries that can address the scenarios outlined in the [Core Use Cases document](../../use-cases.md) (e.g., temporal queries, relationship-based queries, task-oriented queries).
+- Persist RDF triples/quads.
+- Provide mechanisms for adding, updating, and deleting RDF data.
+- Index the RDF data efficiently to support SPARQL queries.
+- Ensure data integrity and consistency within the graph.
+- Support transactions if applicable.
 
 **Interfaces**:
-- Input: Query parameters
-- Output: Metadata results
+- Input: RDF data from the RDF Conversion & Serialization component.
+- Output: Provides data access to the Graph Query Interface.
+
+### 7. Graph Query Interface (SPARQL) (Previously Query Interface)
+
+**Purpose**: Provides a standardized interface (SPARQL endpoint) to query the RDF Triple/Quad Store.
+
+**Responsibilities**:
+- Accept SPARQL queries.
+- Execute queries against the RDF data in the store.
+- Return query results in standard SPARQL result formats (e.g., JSON, XML, CSV) or RDF serializations.
+- Support various SPARQL query forms (SELECT, CONSTRUCT, ASK, DESCRIBE).
+
+**Interfaces**:
+- Input: SPARQL query strings and potentially request parameters (e.g., for result format).
+- Output: Query results.
 
 ## External Components
 
 ### Knowledge Base
-
-The existing personal knowledge base that contains the content to be processed. This is considered external to the system as it is not modified by the Knowledge Base Processor.
+The existing personal knowledge base (collection of Markdown files) that contains the content to be processed. This is read-only from the perspective of the processor.
 
 ### Tools & Integrations
-
-External tools that consume the processed metadata to provide additional functionality, such as visualization, search, or integration with other personal productivity tools.
+External tools or applications that consume the knowledge graph via the Graph Query Interface (SPARQL) to provide functionalities like advanced search, visualization, question answering, or integration with other productivity tools.
 
 ## Component Interactions
 
-1. The **Reader** accesses the knowledge base and normalizes content.
-2. The **Processor** receives normalized content and coordinates processing.
-3. The **Extractor**, **Analyzer**, and **Enricher** process the content to generate metadata.
-4. The **Metadata Store** saves the processed metadata.
-5. The **Query Interface** provides access to the stored metadata.
-6. External **Tools & Integrations** use the Query Interface to access and utilize the metadata.
+1.  The **Reader & Parser** accesses the Knowledge Base, reads Markdown files, and produces a Parsed Document Model for each.
+2.  The **Orchestrator** receives the Parsed Document Model and directs it to the **Analyzer**.
+3.  The **Analyzer** performs document-level inference, enriching the document model.
+4.  The **Orchestrator** passes the Enriched Document Model to the **Extractor**.
+5.  The **Extractor** identifies entities and relationships, outputting them in a structured format.
+6.  The **Orchestrator** sends this structured data to the **RDF Conversion & Serialization** component.
+7.  The **RDF Conversion & Serialization** component transforms the data into RDF triples/quads and sends them to the **RDF Triple/Quad Store**.
+8.  The **RDF Triple/Quad Store** persists and indexes the RDF data.
+9.  The **Graph Query Interface (SPARQL)** provides an endpoint for external **Tools & Integrations** to query the knowledge graph.
 
 ## Design Considerations
 
 ### Modularity
-
-Components are designed to be modular, allowing for:
-- Independent development and testing
-- Selective activation based on needs
-- Easy replacement of individual components
+Components are designed with clear responsibilities and interfaces, allowing for independent development, testing, and potential replacement or enhancement.
 
 ### Statelessness
-
-Core processing components (Extractor, Analyzer, Enricher) are designed to be stateless, making them:
-- Easier to test
-- More reliable
-- Potentially parallelizable if needed
+Where feasible, processing components like the Analyzer, Extractor, and RDF Converter aim to be stateless, processing input and producing output without retaining state between invocations for a given document. The RDF Store is inherently stateful.
 
 ### Extensibility
-
-The system is designed to be extensible in key areas:
-- New extractors can be added for different content types
-- Additional analyzers can be developed for specific metadata needs
-- New enrichers can be created to enhance metadata in different ways
+The architecture supports extensibility:
+- New parsing capabilities can be added to the Reader & Parser.
+- New analysis techniques can be incorporated into the Analyzer.
+- Entity and relationship extraction rules in the Extractor can be expanded.
+- The RDF model can be extended with new vocabulary terms (classes and properties).
+- Different RDF Triple/Quad Store backends can be adopted.
 
 ### Simplicity
-
-In keeping with the lightweight, personal-use focus:
-- Components have clear, focused responsibilities
-- Interfaces between components are straightforward
-- Implementation complexity is minimized where possible
+While the overall system processes complex data, individual components strive for clear, focused responsibilities to manage complexity. The use of RDF and SPARQL introduces powerful standards but also a learning curve.

--- a/docs/architecture/system-overview/components.md
+++ b/docs/architecture/system-overview/components.md
@@ -4,12 +4,14 @@
 
 | Version | Date       | Author        | Changes                                                                 |
 |---------|------------|---------------|-------------------------------------------------------------------------|
+| 0.4     | 2025-05-20 | Roo (AI Asst) | Updated diagram and interactions to show direct stage flow managed by Orchestrator. |
+| 0.3     | 2025-05-20 | Roo (AI Asst) | Clarified Orchestrator role, pipeline structure, and Extractor scope. Added entity modeling note. |
 | 0.2     | 2025-05-18 | Roo (AI Asst) | Updated components for Knowledge Graph/RDF architecture as per ADR-0009. |
 | 0.1     | YYYY-MM-DD | [Name]        | Initial draft                                                           |
 
 ## Overview
 
-The Knowledge Base Processor is composed of several logical components that work together to read, parse, analyze, and transform content from a personal knowledge base into a queryable RDF knowledge graph. This document outlines these components and their relationships, reflecting the architecture described in [ADR-0009](../decisions/0009-knowledge-graph-rdf-store.md).
+The Knowledge Base Processor is composed of several logical components that work together under the management of an **Orchestrator** to read, parse, analyze, and transform content from a personal knowledge base into a queryable RDF knowledge graph. This document outlines these components and their relationships, reflecting the architecture described in [ADR-0009](../decisions/0009-knowledge-graph-rdf-store.md). The Orchestrator manages the end-to-end processing pipeline, coordinating the flow of data between stages.
 
 ## Component Diagram
 
@@ -20,62 +22,74 @@ graph TD
         Tools[Tools & Integrations]
     end
 
-    subgraph "Processing Pipeline"
+    Orchestrator[Orchestrator]
+
+    subgraph "Processing Pipeline Stages"
         Reader["Reader & Parser"]
-        Processor[Orchestrator]
         Analyzer["Analyzer (Document-Level Inference)"]
-        Extractor["Extractor (Entity & Relationship Extraction)"]
+        Extractor["Extractor (NLP & Structural Entity Extraction)"]
         RDFConverter["RDF Conversion & Serialization"]
         RDFStore["RDF Triple/Quad Store"]
         QueryInterface["Graph Query Interface (SPARQL)"]
     end
 
     KB --> Reader
-    Reader --> Processor
-    Processor -- Parsed Document Model --> Analyzer
+    Reader -- Parsed Document Model --> Analyzer
     Analyzer -- Enriched Document Model --> Extractor
-    Extractor -- Entities & Relationships --> RDFConverter
+    Extractor -- Extracted Entities --> RDFConverter
     RDFConverter -- RDF Triples/Quads --> RDFStore
-    RDFStore --> QueryInterface
+    RDFStore -.-> QueryInterface 
     QueryInterface --> Tools
+
+    Orchestrator -- Manages & Initiates --> Reader
+    Orchestrator -- Manages --> Analyzer
+    Orchestrator -- Manages --> Extractor
+    Orchestrator -- Manages --> RDFConverter
+    Orchestrator -- Manages --> RDFStore
+    Orchestrator -- Manages --> QueryInterface
     
     classDef core fill:#cdeccd,stroke:#333,stroke-width:2px;
     classDef storage fill:#e2d6ff,stroke:#333,stroke-width:2px;
     classDef external fill:#f5f5f5,stroke:#333,stroke-width:1px;
+    classDef orchestrator fill:#ffe4b5,stroke:#333,stroke-width:2px;
     
-    class Reader,Processor,Analyzer,Extractor,RDFConverter,QueryInterface core;
+    class Reader,Analyzer,Extractor,RDFConverter,QueryInterface core;
     class RDFStore storage;
     class KB,Tools external;
+    class Orchestrator orchestrator;
 ```
 
 ## Core Components
 
-### 1. Reader & Parser (Previously Reader)
+### 1. Orchestrator (Previously Processor)
 
-**Purpose**: Reads content from the knowledge base (Markdown files) and parses it into a structured internal representation.
+**Purpose**: Manages and coordinates the entire data processing pipeline, from initial document ingestion to final RDF graph population and query. It ensures a seamless flow of data through various specialized components by initiating processes and overseeing their execution.
 
 **Responsibilities**:
-- Access the knowledge base files.
+- Initiate the processing pipeline starting with the Reader & Parser.
+- Control the overall sequence of operations and ensure data flows correctly between the Reader & Parser, Analyzer, Extractor, RDF Conversion & Serialization, and RDF Store.
+- Monitor the status of each processing stage.
+- Handle pipeline-level error management, logging, and status tracking.
+- Provide a central point of control and configuration for the processing workflow.
+
+**Interfaces**:
+- Input: Configuration for the processing run, signals to start processing.
+- Output: Final status of the processing, logs, and indirectly, the populated RDF Store.
+- Interacts with: All other core components by initiating their tasks, monitoring them, and managing the overall workflow.
+
+### 2. Reader & Parser (Previously Reader)
+
+**Purpose**: Reads content from the knowledge base (Markdown files) and parses it into a structured internal representation. This is the first active stage in the pipeline.
+
+**Responsibilities**:
+- Access the knowledge base files upon instruction from the Orchestrator.
 - Parse Markdown syntax (frontmatter, headings, paragraphs, links, code blocks, etc.).
 - Create a "Parsed Document Model" – a structured object representing the document's content and explicit metadata.
 - Track which content has been processed.
 
 **Interfaces**:
-- Input: Knowledge base location (file paths).
-- Output: Parsed Document Model objects.
-
-### 2. Orchestrator (Previously Processor)
-
-**Purpose**: Orchestrates the overall data processing workflow from document parsing to RDF graph population.
-
-**Responsibilities**:
-- Coordinate the flow of data through Analyzer, Extractor, and RDFConverter components.
-- Manage the sequence of operations for each document.
-- Handle processing errors and logging.
-
-**Interfaces**:
-- Input: Parsed Document Model from Reader & Parser.
-- Output: Directs data to subsequent components (Analyzer, Extractor).
+- Input: Knowledge base location (file paths), invocation triggered by Orchestrator.
+- Output: Parsed Document Model objects to the Analyzer.
 
 ### 3. Analyzer (Document-Level Inference)
 
@@ -85,47 +99,47 @@ graph TD
 - Identify main topics or themes of the document.
 - Generate or suggest relevant tags/keywords.
 - Potentially create document summaries.
-- This stage enriches the Parsed Document Model before specific entities and relationships are extracted for the graph.
+- This stage enriches the Parsed Document Model before specific entities are extracted.
 
 **Interfaces**:
-- Input: Parsed Document Model from Orchestrator.
-- Output: Enriched Document Model (with inferred topics, tags, etc.).
+- Input: Parsed Document Model from the Reader & Parser.
+- Output: Enriched Document Model (with inferred topics, tags, etc.) to the Extractor.
 
-### 4. Extractor (Entity & Relationship Extraction)
+### 4. Extractor (NLP & Structural Entity Extraction)
 
-**Purpose**: Identifies and extracts specific entities and the relationships between them from the Enriched Document Model.
+**Purpose**: Identifies and extracts specific entities from the Enriched Document Model using Natural Language Processing (NLP) techniques and structural analysis.
 
 **Responsibilities**:
-- Recognize named entities (People, Organizations, Locations, Dates, Projects, Meetings, Concepts like "ToDo Item") and assign them types.
-- Identify relationships between these entities (e.g., "Person A *attends* Meeting X", "Document Z *mentions* Topic Y").
-- Utilize both explicit information (e.g., from frontmatter, wikilinks) and context from the document content.
+- Recognize named entities (People, Organizations, Locations, Dates, Projects, Meetings, Concepts like "ToDo Item") using NLP.
+- Extract entities based on structural cues in the document (e.g., from frontmatter, wikilinks, specific Markdown patterns).
+- Assign types to identified entities.
+- Model explicit entities as Python objects where possible.
 
 **Interfaces**:
-- Input: Enriched Document Model from Analyzer.
-- Output: A structured list of identified entities and relationships.
+- Input: Enriched Document Model from the Analyzer.
+- Output: A structured list of identified entities to the RDF Conversion & Serialization component.
 
-### 5. RDF Conversion & Serialization (New Component)
+### 5. RDF Conversion & Serialization
 
-**Purpose**: Transforms the extracted entities and relationships into RDF triples or quads.
+**Purpose**: Transforms the extracted entities into RDF triples or quads.
 
 **Responsibilities**:
 - Map entities to RDF resources (assigning URIs).
 - Map entity types to RDF classes (e.g., `foaf:Person`, `kb:Meeting`).
 - Map entity attributes to RDF properties (e.g., `foaf:name`, `dcterms:title`).
-- Map relationships to RDF predicates (e.g., `kb:attends`, `kb:discussesTopic`).
 - Serialize the RDF data into a standard format (e.g., Turtle, N-Quads, JSON-LD).
 - Potentially assign triples/quads to named graphs (e.g., based on source document URI for provenance).
 
 **Interfaces**:
-- Input: Structured list of entities and relationships from Extractor.
-- Output: RDF data (e.g., a stream of triples/quads or a serialized RDF document).
+- Input: Structured list of entities from the Extractor.
+- Output: RDF data (e.g., a stream of triples/quads or a serialized RDF document) to the RDF Triple/Quad Store.
 
 ### 6. RDF Triple/Quad Store (Previously Metadata Store)
 
 **Purpose**: Stores, manages, and indexes the generated RDF data, forming the knowledge graph.
 
 **Responsibilities**:
-- Persist RDF triples/quads.
+- Persist RDF triples/quads received from the RDF Conversion & Serialization component.
 - Provide mechanisms for adding, updating, and deleting RDF data.
 - Index the RDF data efficiently to support SPARQL queries.
 - Ensure data integrity and consistency within the graph.
@@ -137,7 +151,7 @@ graph TD
 
 ### 7. Graph Query Interface (SPARQL) (Previously Query Interface)
 
-**Purpose**: Provides a standardized interface (SPARQL endpoint) to query the RDF Triple/Quad Store.
+**Purpose**: Provides a standardized interface (SPARQL endpoint) to query the RDF Triple/Quad Store. This interface is managed and exposed under the Orchestrator's control.
 
 **Responsibilities**:
 - Accept SPARQL queries.
@@ -157,33 +171,36 @@ The existing personal knowledge base (collection of Markdown files) that contain
 ### Tools & Integrations
 External tools or applications that consume the knowledge graph via the Graph Query Interface (SPARQL) to provide functionalities like advanced search, visualization, question answering, or integration with other productivity tools.
 
-## Component Interactions
+## Component Interactions & Pipeline Flow
 
-1.  The **Reader & Parser** accesses the Knowledge Base, reads Markdown files, and produces a Parsed Document Model for each.
-2.  The **Orchestrator** receives the Parsed Document Model and directs it to the **Analyzer**.
-3.  The **Analyzer** performs document-level inference, enriching the document model.
-4.  The **Orchestrator** passes the Enriched Document Model to the **Extractor**.
-5.  The **Extractor** identifies entities and relationships, outputting them in a structured format.
-6.  The **Orchestrator** sends this structured data to the **RDF Conversion & Serialization** component.
-7.  The **RDF Conversion & Serialization** component transforms the data into RDF triples/quads and sends them to the **RDF Triple/Quad Store**.
-8.  The **RDF Triple/Quad Store** persists and indexes the RDF data.
-9.  The **Graph Query Interface (SPARQL)** provides an endpoint for external **Tools & Integrations** to query the knowledge graph.
+The **Orchestrator** initiates and manages the processing pipeline, while data flows sequentially through the stages:
+
+1.  The **Orchestrator** initiates processing by instructing the **Reader & Parser** to access the Knowledge Base.
+2.  The **Reader & Parser** reads Markdown files and produces a Parsed Document Model, passing it directly to the **Analyzer**.
+3.  The **Analyzer** performs document-level inference, enriching the model, and passes the Enriched Document Model directly to the **Extractor**.
+4.  The **Extractor** identifies entities and passes the structured list of entities directly to the **RDF Conversion & Serialization** component.
+5.  The **RDF Conversion & Serialization** component transforms the data into RDF triples/quads and sends them directly to the **RDF Triple/Quad Store** for persistence.
+6.  The **Orchestrator** oversees this entire flow, managing errors, logging, and coordination between stages.
+7.  The **Graph Query Interface (SPARQL)**, managed by the Orchestrator, provides an endpoint for external **Tools & Integrations** to query the knowledge graph stored in the **RDF Triple/Quad Store**.
 
 ## Design Considerations
 
 ### Modularity
-Components are designed with clear responsibilities and interfaces, allowing for independent development, testing, and potential replacement or enhancement.
+Components are designed with clear responsibilities and interfaces, allowing for independent development, testing, and potential replacement or enhancement. The Orchestrator ensures these modular components work together cohesively in a defined sequence.
 
 ### Statelessness
-Where feasible, processing components like the Analyzer, Extractor, and RDF Converter aim to be stateless, processing input and producing output without retaining state between invocations for a given document. The RDF Store is inherently stateful.
+Where feasible, processing components like the Analyzer, Extractor, and RDF Converter aim to be stateless, processing input and producing output without retaining state between invocations for a given document. The RDF Store is inherently stateful. The Orchestrator manages the state and progress of the overall pipeline flow.
 
 ### Extensibility
 The architecture supports extensibility:
 - New parsing capabilities can be added to the Reader & Parser.
 - New analysis techniques can be incorporated into the Analyzer.
-- Entity and relationship extraction rules in the Extractor can be expanded.
+- Entity extraction rules and NLP models in the Extractor can be expanded or updated.
 - The RDF model can be extended with new vocabulary terms (classes and properties).
 - Different RDF Triple/Quad Store backends can be adopted.
 
+### Entity Modeling
+Explicit entities identified by the **Extractor** should be modeled as Python objects where possible. This allows for strong typing, validation, and easier manipulation within the Python-based processing pipeline before conversion to RDF.
+
 ### Simplicity
-While the overall system processes complex data, individual components strive for clear, focused responsibilities to manage complexity. The use of RDF and SPARQL introduces powerful standards but also a learning curve.
+While the overall system processes complex data, individual components strive for clear, focused responsibilities to manage complexity. The Orchestrator simplifies the overall control flow by managing the sequence and interaction of these components. The use of RDF and SPARQL introduces powerful standards but also a learning curve.

--- a/docs/architecture/system-overview/data-flow.md
+++ b/docs/architecture/system-overview/data-flow.md
@@ -2,285 +2,352 @@
 
 ## Revision History
 
-| Version | Date       | Author | Changes                              |
-|---------|------------|--------|--------------------------------------|
-| 0.1     | YYYY-MM-DD | [Name] | Initial draft                        |
+| Version | Date       | Author        | Changes                                                                 |
+|---------|------------|---------------|-------------------------------------------------------------------------|
+| 0.2     | 2025-05-18 | Roo (AI Asst) | Revised data flow for Knowledge Graph/RDF architecture. Updated diagram, transformations, and models. |
+| 0.1     | YYYY-MM-DD | [Name]        | Initial draft                                                           |
 
 ## Overview
 
-This document describes how data flows through the Knowledge Base Processor system, from the initial content in the knowledge base to the final structured metadata that can be queried and utilized.
+This document describes how data flows through the Knowledge Base Processor system, from the initial raw content in the knowledge base to the final structured knowledge graph representation in an RDF triple/quad store, which can then be queried. This revised flow reflects the architectural shift towards a knowledge graph model as per [ADR-0009](../decisions/0009-knowledge-graph-rdf-store.md).
 
 ## High-Level Data Flow
 
+The new data flow emphasizes a multi-stage process, transforming raw documents into a queryable knowledge graph:
+
 ```mermaid
 flowchart LR
-    A[Raw Content] --> B[Normalized Content]
-    B --> C[Extracted Metadata]
-    B --> D[Analyzed Metadata]
-    C --> E[Enhanced Metadata]
-    D --> E
-    E --> F[Stored Metadata]
-    F --> G[Queryable Metadata]
-    
+    A[Raw Markdown Document] --> B[Parsed Document Model]
+    B --> C[Document-Level Inference (Topics, Tags, etc.)]
+    C --> D[Entity & Relationship Extraction]
+    D --> E[Typed Graph Nodes & Edges (RDF Triples/Quads)]
+    E --> F[RDF Triple/Quad Store]
+    F --> G[Graph Query Interface (SPARQL)]
+
     style A fill:#f5f5f5,stroke:#333,stroke-width:1px
     style B fill:#d4f1f9,stroke:#333,stroke-width:1px
-    style C fill:#d1e7dd,stroke:#333,stroke-width:1px
-    style D fill:#d1e7dd,stroke:#333,stroke-width:1px
-    style E fill:#d1e7dd,stroke:#333,stroke-width:1px
+    style C fill:#cdeccd,stroke:#333,stroke-width:1px
+    style D fill:#f9e79f,stroke:#333,stroke-width:1px
+    style E fill:#f5cba7,stroke:#333,stroke-width:1px
     style F fill:#e2d6ff,stroke:#333,stroke-width:1px
     style G fill:#ffe6cc,stroke:#333,stroke-width:1px
 ```
 
 ## Data Transformations
 
-### 1. Raw Content → Normalized Content
+### 1. Raw Markdown Document → Parsed Document Model
 
-**Performed by**: Reader Component
+**Performed by**: Reader Component & Markdown Parser Component
 
 **Transformation**:
-- Content is read from its native format (Markdown, text, etc.)
-- Formatting is parsed and normalized
-- Content is structured into a consistent internal representation
-- Basic metadata like filename, path, and modification date are captured
+- Content is read from its native Markdown format.
+- Markdown syntax (frontmatter, headings, lists, links, code blocks, etc.) is parsed into a structured tree or object model.
+- This model represents the document's explicit structure and content elements.
+- Basic source metadata (filename, path, modification date) is captured.
 
 **Example**:
 ```
-Raw: A Markdown file with frontmatter, headings, and text
+Raw: A Markdown file with YAML frontmatter, headings, paragraphs, and wikilinks.
 ↓
-Normalized: An object with parsed frontmatter, content sections, and basic metadata
+Parsed Document Model: An object representing the document's structure, including:
+  - Frontmatter: as a key-value map.
+  - Sections: hierarchical structure based on headings.
+  - Content Blocks: paragraphs, lists, code blocks, etc.
+  - Links: extracted with their text and target.
+  - Source Path: "sample_data/MyNote.md"
 ```
 
-### 2. Normalized Content → Extracted Metadata
+### 2. Parsed Document Model → Document-Level Inference
 
-**Performed by**: Extractor Component
+**Performed by**: Analyzer Component (Topic Modeling, Tag Generation, Summarization modules)
 
 **Transformation**:
-- Explicit metadata is identified and extracted
-- Structured elements are parsed for metadata
-- References and links are extracted
-- Tags, categories, and other explicit classifications are captured
+- The content of the Parsed Document Model is analyzed to infer higher-level document-wide attributes.
+- This can include:
+    - **Topic Identification**: Determining main topics or themes of the document.
+    - **Tag/Keyword Generation**: Suggesting relevant tags or keywords based on content.
+    - **Summarization**: Creating a concise summary of the document.
+    - **Language Detection**: Identifying the primary language of the document.
+- These inferences enrich the document model before specific entities and relationships are extracted for the graph.
 
 **Example**:
 ```
-Normalized Content: Parsed document with frontmatter and content
+Parsed Document Model: Structured content of "MyNote.md".
 ↓
-Extracted Metadata: Tags, categories, explicit references, dates
+Document-Level Inference attached to the model:
+  - Inferred Topics: ["Software Architecture", "Knowledge Graphs", "RDF"]
+  - Suggested Tags: ["adr", "data-modeling", "semantics"]
+  - Summary: "This note discusses the shift to an RDF-based knowledge graph..."
 ```
 
-### 3. Normalized Content → Analyzed Metadata
+### 3. Document-Level Inference → Entity & Relationship Extraction
 
-**Performed by**: Analyzer Component
+**Performed by**: Extractor Component (Entity Recognition, Relationship Extraction modules)
 
 **Transformation**:
-- Content is analyzed for topics and themes
-- Entities (people, places, concepts) are identified
-- Implicit categories are determined
-- Relevance scores are calculated
+- The Parsed Document Model (now enriched with document-level inferences) is processed to identify specific entities and the relationships between them.
+- **Entities**: Named entities (People, Organizations, Locations, Dates, Projects, Meetings, Concepts like "ToDo Item") are recognized and typed.
+- **Relationships**: Connections between these entities are identified (e.g., "Person A *attends* Meeting X", "Meeting X *discusses* Topic Y", "Document Z *mentions* Person A").
+- Explicitly stated metadata (e.g., from frontmatter) and implicitly derived information are used.
 
 **Example**:
 ```
-Normalized Content: Parsed document content
+Enriched Document Model for "MyNote.md"
 ↓
-Analyzed Metadata: Topics, entities, sentiment, complexity metrics
+Extracted Entities & Relationships:
+  - Entity: { id: "person_jane_doe", type: "Person", name: "Jane Doe" }
+  - Entity: { id: "meeting_project_alpha_20251107", type: "Meeting", label: "Project Alpha Sync", date: "2025-11-07" }
+  - Entity: { id: "topic_knowledge_graph", type: "Topic", label: "Knowledge Graph" }
+  - Relationship: { source: "person_jane_doe", type: "attended", target: "meeting_project_alpha_20251107" }
+  - Relationship: { source: "meeting_project_alpha_20251107", type: "discussedTopic", target: "topic_knowledge_graph" }
 ```
 
-### 4. Extracted & Analyzed Metadata → Enhanced Metadata
+### 4. Entity & Relationship Extraction → Typed Graph Nodes & Edges (RDF Triples/Quads)
 
-**Performed by**: Enricher Component
+**Performed by**: RDF Conversion/Serialization Component
 
 **Transformation**:
-- Relationships between content items are established
-- Hierarchical structures are identified
-- Metadata is enriched with additional context
-- Summaries or abstracts may be generated
+- The extracted entities and relationships are transformed into RDF statements (triples or quads).
+- **Entities become RDF Resources (Nodes)**: Each entity is assigned a URI (e.g., `kb:person_jane_doe`). Properties of the entity (name, type) become RDF properties attached to this resource (e.g., `kb:person_jane_doe rdf:type foaf:Person; foaf:name "Jane Doe".`).
+- **Relationships become RDF Predicates (Edges)**: Relationships link two RDF resources (e.g., `kb:person_jane_doe meeting:attended kb:meeting_project_alpha_20251107.`).
+- Literals (strings, numbers, dates) are used for attribute values.
+- Quads can be used to associate statements with a named graph, often representing the source document URI.
+
+**Example (Turtle Syntax for RDF)**:
+```turtle
+@prefix kb: <http://example.org/kb/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix meeting: <http://example.org/ontology/meeting/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+kb:person_jane_doe a foaf:Person ;
+    foaf:name "Jane Doe" .
+
+kb:meeting_project_alpha_20251107 a meeting:Meeting ;
+    dcterms:title "Project Alpha Sync" ;
+    dcterms:date "2025-11-07"^^xsd:date ;
+    meeting:discussedTopic kb:topic_knowledge_graph .
+
+kb:person_jane_doe meeting:attended kb:meeting_project_alpha_20251107 .
+
+kb:topic_knowledge_graph a dcterms:Subject ;
+    dcterms:title "Knowledge Graph" .
+
+# Example of a quad (if using named graphs, e.g., associating with source document)
+# kb:source_MyNote_md {
+#   kb:person_jane_doe meeting:attended kb:meeting_project_alpha_20251107 .
+# }
+```
+
+### 5. RDF Triples/Quads → RDF Triple/Quad Store
+
+**Performed by**: Metadata Store Component (RDF Store Interface)
+
+**Transformation**:
+- The generated RDF triples/quads are loaded into a persistent RDF triple/quad store.
+- The store indexes the RDF data to enable efficient querying.
+- This store becomes the primary source for structured, queryable knowledge.
 
 **Example**:
 ```
-Extracted & Analyzed Metadata: Tags, topics, entities
+RDF Triples/Quads (e.g., in Turtle or N-Quads format)
 ↓
-Enhanced Metadata: Related content links, hierarchical categorization, enriched entities
+Stored & Indexed in RDF Database (e.g., Apache Jena TDB, Oxigraph, RDF4J Native Store)
 ```
 
-### 5. Enhanced Metadata → Stored Metadata
+### 6. RDF Triple/Quad Store → Graph Query Interface (SPARQL)
 
-**Performed by**: Metadata Store Component
+**Performed by**: Query Interface Component (SPARQL Endpoint)
 
 **Transformation**:
-- Metadata is formatted for storage
-- Relationships are encoded
-- Indexing structures are created
-- Metadata is persisted
+- The RDF store provides a query endpoint, typically supporting SPARQL.
+- User queries (or programmatic queries) are formulated in SPARQL.
+- The SPARQL engine in the RDF store executes these queries against the graph data.
+- Results are returned in standard formats (e.g., SPARQL JSON Results Format, XML, CSV, RDF serializations).
 
 **Example**:
 ```
-Enhanced Metadata: Rich metadata objects with relationships
+SPARQL Query:
+  SELECT ?meetingTitle WHERE {
+    kb:person_jane_doe meeting:attended ?meeting .
+    ?meeting dcterms:title ?meetingTitle .
+  }
 ↓
-Stored Metadata: Persisted data with appropriate indexing
-```
-
-### 6. Stored Metadata → Queryable Metadata
-
-**Performed by**: Query Interface Component
-
-**Transformation**:
-- Stored metadata is made available through query interfaces
-- Query parameters are translated to storage operations
-- Results are formatted for consumption
-- Access patterns are optimized
-
-**Example**:
-```
-Stored Metadata: Indexed, persisted metadata
-↓
-Queryable Metadata: Results formatted for specific query needs
-
-### Conceptual Query Examples (Illustrative)
-
-The following examples illustrate conceptually how the [Core Use Cases](../../use-cases.md) might be addressed by querying the `Queryable Metadata`. These are not literal query syntax but demonstrate the type of logic involved.
-
-*   **Use Case:** "When was my last meeting with Jane Doe?"
-    *   **Conceptual Query:** `SELECT MAX(date) FROM metadata WHERE metadata.analyzed.entities CONTAINS {name: "Jane Doe", type: "person"} AND (metadata.extracted.tags CONTAINS "meeting" OR metadata.analyzed.topics CONTAINS "meeting")`
-
-*   **Use Case:** "What are my meeting follow-ups from my last meeting about Project Alpha?"
-    *   **Conceptual Query:** `SELECT todo_item.text FROM metadata JOIN todo_items ON metadata.content_id = todo_item.content_id WHERE metadata.analyzed.topics CONTAINS {name: "Project Alpha"} AND todo_item.status = "open" AND todo_item.context_is_meeting_follow_up` (Assumes `todo_items` are extracted and linkable).
-
-*   **Use Case:** "How do I know John Smith?"
-    *   **Conceptual Query:** `SELECT metadata.analyzed.entities.mentions.context, metadata.content_id FROM metadata WHERE metadata.analyzed.entities CONTAINS {name: "John Smith", type: "person"} ORDER BY date LIMIT 5`
-
-*   **Use Case:** "What is my list of writing ideas that haven't been completed?"
-    *   **Conceptual Query:** `SELECT todo_item.text FROM todo_items WHERE todo_item.tags CONTAINS "writing_idea" AND todo_item.status = "open"` (Assumes `todo_items` are extracted with tags/types).
+Query Results: (e.g., JSON)
+  { "results": { "bindings": [ { "meetingTitle": { "type": "literal", "value": "Project Alpha Sync" } } ] } }
 ```
 
 ## Data Models
 
-### Content Model
+### Parsed Document Model (Intermediate)
 
-The internal representation of content after normalization:
+This model is an internal, structured representation of the source Markdown document after initial parsing. It serves as input for document-level inference and entity/relationship extraction.
 
 ```json
 {
-  "id": "unique-identifier",
+  "id": "doc_mynote_md", // Derived from file path or a UUID
   "source": {
-    "path": "path/to/file.md",
+    "path": "sample_data/MyNote.md",
     "type": "markdown",
     "lastModified": "2023-05-01T12:00:00Z"
   },
-  "content": {
-    "title": "Document Title",
-    "body": "Normalized content body",
-    "sections": [
-      {
-        "level": 1,
-        "title": "Section Title",
-        "content": "Section content"
-      }
-    ]
+  "frontmatter": {
+    "title": "My Awesome Note",
+    "tags": ["project-x", "research"],
+    "created": "2023-04-15"
   },
-  "explicit_metadata": {
-    "tags": ["tag1", "tag2"],
-    "categories": ["category1"],
-    "created": "2023-04-15T10:30:00Z"
+  "content_elements": [ // Simplified list of elements
+    { "type": "heading", "level": 1, "text": "Main Section" },
+    { "type": "paragraph", "text": "This note discusses [[Topic A]] and mentions @JaneDoe." },
+    { "type": "wikilink", "target": "Topic A", "text": "[[Topic A]]" },
+    { "type": "mention", "target": "JaneDoe", "text": "@JaneDoe" }
+  ],
+  "inferred_metadata": { // Populated by Document-Level Inference stage
+    "topics": [ { "uri": "kb:topic_software_architecture", "label": "Software Architecture", "score": 0.85 } ],
+    "summary": "A brief summary of the note's content..."
   }
 }
 ```
 
-### Metadata Model
+### Knowledge Graph Model (RDF)
 
-The representation of processed metadata:
+The primary data model for queryable knowledge is an RDF graph. Data is represented as a set of triples (subject, predicate, object) or quads (graph, subject, predicate, object).
 
-```json
-{
-  "content_id": "unique-identifier",
-  "extracted": {
-    "tags": ["tag1", "tag2"],
-    "categories": ["category1"],
-    "references": [
-      {
-        "type": "link",
-        "target": "another-document-id",
-        "context": "Link context"
-      }
-    ],
-    "dates": {
-      "created": "2023-04-15T10:30:00Z",
-      "mentioned": ["2023-05-10", "2022-11-30"]
-    }
-    // Note: To fully support use cases like task tracking, this section would also include
-    // extracted to-do items with their status, context, and any associated dates or projects.
-    // e.g., "todo_items": [{ "text": "Draft proposal", "status": "open", "project": "Project Alpha" }]
-  },
-  "analyzed": {
-    "topics": [
-      {
-        "name": "Topic Name",
-        "confidence": 0.85,
-        "keywords": ["keyword1", "keyword2"]
-      }
-    ],
-    "entities": [
-      {
-        "name": "Entity Name",
-        "type": "person",
-        "confidence": 0.92,
-        "mentions": [
-          {
-            "position": 156,
-            "context": "surrounding text"
-          }
-        ]
-      }
-    ],
-    "metrics": {
-      "complexity": 0.65,
-      "sentiment": 0.2
-    }
-  },
-  "enhanced": {
-    "related_content": [
-      {
-        "id": "related-document-id",
-        "relationship": "similar-topic",
-        "strength": 0.78
-      }
-    ],
-    "hierarchy": {
-      "parent": "parent-document-id",
-      "children": ["child-document-id"]
-    },
-    "summary": "Brief generated summary of the content"
-  }
-  // Note: To fully support use cases like "employee of" or "organization is part of",
-  // this section could include a more generic "relationships" array.
-  // e.g., "relationships": [{ "type": "employee_of", "source_id": "entity_person_X", "target_id": "entity_org_Y" }]
-}
-```
+**Conceptual RDF Structure (Illustrated with Turtle-like examples):**
+
+-   **Entities as Resources with Types and Properties:**
+    ```turtle
+    @prefix kb: <http://example.org/kb/> .
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix schema: <http://schema.org/> .
+    @prefix dcterms: <http://purl.org/dc/terms/> .
+
+    kb:person_john_smith a foaf:Person ;  # rdf:type
+        foaf:name "John Smith" ;
+        schema:email "john.smith@example.com" ;
+        dcterms:created "2024-01-10T10:00:00Z"^^xsd:dateTime .
+
+    kb:meeting_project_review_20250518 a schema:Event, kb:Meeting ; # Multiple types
+        schema:name "Project Review Q2" ;
+        schema:startDate "2025-05-18T14:00:00Z"^^xsd:dateTime ;
+        schema:location kb:location_room_301 ;
+        dcterms:source <file:///workspaces/knowledgebase-processor/sample_data/meeting_notes_20250518.md> .
+    ```
+
+-   **Relationships as Predicates:**
+    ```turtle
+    kb:person_john_smith schema:attendee kb:meeting_project_review_20250518 .
+    kb:meeting_project_review_20250518 kb:discussesTopic kb:topic_performance_metrics .
+    kb:document_adr0009 dcterms:references kb:person_john_smith . # A document mentioning a person
+    ```
+
+-   **Literals for Data Values:**
+    - Strings: `"John Smith"`
+    - Dates: `"2025-05-18"^^xsd:date`
+    - Numbers: `"42"^^xsd:integer`
+
+-   **Vocabularies/Ontologies**: Standard (FOAF, Schema.org, Dublin Core) and custom vocabularies (e.g., `kb:`) will be used to define classes (e.g., `kb:Meeting`, `kb:ToDoItem`) and properties (e.g., `kb:hasStatus`, `kb:assignedTo`).
+
+The actual RDF serialization (e.g., Turtle, N-Triples, JSON-LD) will be chosen based on storage and processing needs.
+
+## Conceptual Query Examples (Illustrative SPARQL)
+
+The following examples illustrate conceptually how the [Core Use Cases](../../use-cases.md) might be addressed by querying the RDF graph using SPARQL.
+
+*   **Use Case:** "When was my last meeting with Jane Doe?"
+    *   **Conceptual SPARQL Query:**
+        ```sparql
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX schema: <http://schema.org/>
+        PREFIX kb: <http://example.org/kb/>
+
+        SELECT (MAX(?date) AS ?lastMeetingDate)
+        WHERE {
+          ?person foaf:name "Jane Doe" .
+          ?meeting a kb:Meeting ;
+                   schema:attendee ?person ;
+                   schema:startDate ?date .
+        }
+        ```
+
+*   **Use Case:** "What are my meeting follow-ups (ToDo items) from my last meeting about Project Alpha?"
+    *   **Conceptual SPARQL Query:**
+        ```sparql
+        PREFIX schema: <http://schema.org/>
+        PREFIX kb: <http://example.org/kb/>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+
+        SELECT ?todoText
+        WHERE {
+          ?meeting a kb:Meeting ;
+                   dcterms:title ?meetingTitle ;
+                   kb:generatesToDo ?todoItem .
+          FILTER CONTAINS(LCASE(?meetingTitle), "project alpha") # Simplified title match
+          # Further filter for "last meeting" if needed, e.g., by date
+
+          ?todoItem a kb:ToDoItem ;
+                    kb:hasStatus kb:status_Open ; # Assuming kb:status_Open is a defined resource
+                    schema:text ?todoText .
+        }
+        ORDER BY DESC(?meetingDate) # Assuming ?meetingDate is available for the meeting
+        LIMIT 10 # For follow-ups from the most recent relevant meeting
+        ```
+
+*   **Use Case:** "How do I know John Smith?" (Show contexts where John Smith is mentioned)
+    *   **Conceptual SPARQL Query:**
+        ```sparql
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX kb: <http://example.org/kb/>
+
+        SELECT ?sourceDocument ?mentionContext (COUNT(?mention) AS ?mentionCount)
+        WHERE {
+          ?person foaf:name "John Smith" .
+          # Assuming mentions are reified or linked to source documents
+          ?mention kb:refersToEntity ?person ;
+                   kb:hasContext ?mentionContext ;
+                   dcterms:source ?sourceDocument . # URI of the source document
+        }
+        GROUP BY ?sourceDocument ?mentionContext
+        ORDER BY DESC(?mentionCount)
+        LIMIT 5
+        ```
+
+*   **Use Case:** "What is my list of writing ideas (ToDo items) that haven't been completed?"
+    *   **Conceptual SPARQL Query:**
+        ```sparql
+        PREFIX schema: <http://schema.org/>
+        PREFIX kb: <http://example.org/kb/>
+
+        SELECT ?ideaText
+        WHERE {
+          ?todoItem a kb:ToDoItem ;
+                    kb:hasCategory kb:category_WritingIdea ; # Assuming a category system
+                    kb:hasStatus kb:status_Open ;
+                    schema:text ?ideaText .
+        }
+        ```
 
 ## Data Flow Considerations
 
 ### Incremental Processing
-
-The system supports incremental processing, where:
-- Only new or modified content is fully processed
-- Existing metadata is preserved when possible
-- Relationships are updated as needed
+- The system should support incremental processing. When a Markdown file is modified, only the affected parts of the document model and the corresponding RDF triples/quads should be updated in the store.
+- This might involve deleting old triples related to the document and inserting new ones. Strategies like using named graphs per document can facilitate this.
 
 ### Data Integrity
-
-To maintain data integrity:
-- Content IDs provide stable references
-- Metadata is versioned alongside content
-- Processing errors are tracked and can be addressed
+- URIs for resources (entities, documents) must be stable and consistently generated.
+- Vocabulary terms (classes and properties) should be managed, potentially using a simple ontology.
+- Provenance of data (e.g., which document a triple originated from) can be tracked using quads/named graphs or reification.
 
 ### Performance Considerations
-
-For a personal-use system:
-- Processing can be done in batches during idle times
-- Full processing of large knowledge bases may be done incrementally
-- Query performance is prioritized over processing speed
+- SPARQL query performance will depend on the chosen RDF store, the size of the graph, and the complexity of queries. Indexing strategies within the RDF store are crucial.
+- For a personal-use system, batch processing for graph updates is acceptable. Query performance for common use cases should be prioritized.
 
 ### Storage Efficiency
+- RDF can be verbose. Choosing efficient serialization formats (e.g., Turtle, or binary RDF formats if supported by the store) for storage or transfer can be important.
+- The RDF store itself will have its own storage footprint.
 
-To keep the system lightweight:
-- Metadata is stored separately from content
-- Only necessary information is retained
-- Duplicate data is minimized
+### Schema and Ontology Management
+- A basic ontology defining custom classes (e.g., `kb:Meeting`, `kb:ToDoItem`, `kb:Project`) and properties (e.g., `kb:discussesTopic`, `kb:hasStatus`, `kb:assignedTo`) will be necessary.
+- Standard vocabularies (FOAF, Schema.org, DCTerms) should be reused where possible.

--- a/docs/architecture/system-overview/data-flow.md
+++ b/docs/architecture/system-overview/data-flow.md
@@ -18,11 +18,11 @@ The new data flow emphasizes a multi-stage process, transforming raw documents i
 ```mermaid
 flowchart LR
     A[Raw Markdown Document] --> B[Parsed Document Model]
-    B --> C[Document-Level Inference (Topics, Tags, etc.)]
+    B --> C[Document-Level Inference - Topics, Tags, etc.]
     C --> D[Entity & Relationship Extraction]
-    D --> E[Typed Graph Nodes & Edges (RDF Triples/Quads)]
+    D --> E[Typed Graph Nodes & Edges RDF Triples/Quads]
     E --> F[RDF Triple/Quad Store]
-    F --> G[Graph Query Interface (SPARQL)]
+    F --> G[Graph Query Interface - SPARQL]
 
     style A fill:#f5f5f5,stroke:#333,stroke-width:1px
     style B fill:#d4f1f9,stroke:#333,stroke-width:1px

--- a/docs/features/planned/todo-item-extraction-to-rdf.md
+++ b/docs/features/planned/todo-item-extraction-to-rdf.md
@@ -1,0 +1,144 @@
+# Feature Specification: Todo Item Extraction to RDF
+
+## Revision History
+
+| Version | Date       | Author        | Changes                              |
+|---------|------------|---------------|--------------------------------------|
+| 0.1     | 2025-05-18 | Roo (AI Asst) | Initial draft                        |
+
+## Feature Name
+
+Todo Item Extraction to RDF
+
+## Status
+
+Proposed
+
+## Summary
+
+This feature enables the extraction of todo items (tasks) from Markdown documents and their representation as structured RDF resources within the knowledge graph. This allows tasks to be queried, managed, and related to other entities in the graph.
+
+## Motivation
+
+Todo items are a critical piece of information in many personal knowledge bases. Representing them as first-class citizens in the RDF graph, rather than just plain text, allows for:
+- Centralized querying of all tasks across the knowledge base.
+- Tracking task status (open/completed).
+- Linking tasks to relevant documents, projects, people, or meetings.
+- Building dedicated task management views or integrations.
+- Analyzing task distribution, completion rates, and contexts.
+
+## User Stories
+
+- As a user, I want my Markdown todo items (e.g., `- [ ] Review ADR-0009`) to be automatically identified and added to the knowledge graph, so that I can query and manage them centrally.
+- As a user, I want the status of my todo items (open or completed, e.g., `- [ ]` vs. `- [x]`) to be accurately reflected as a property of the task in the RDF graph.
+- As a user, I want each extracted todo item in the graph to be linked back to its source Markdown document, so I can easily find its original context.
+- As a user, I want todo items that mention specific entities (e.g., `Discuss [[Project Phoenix]] with @JaneDoe`) to potentially be linked to those entities in the RDF graph, so I can see tasks related to a project or person.
+
+## Detailed Description
+
+The system will parse Markdown content to identify lines that represent todo items, typically formatted as:
+- `- [ ] An open task`
+- `- [x] A completed task`
+- `* [ ] Another open task`
+- `* [X] Another completed task` (case-insensitive 'x')
+
+For each identified todo item, an RDF resource of type `kb:ToDoItem` (or a similar class from a chosen vocabulary) will be created. This resource will have properties including:
+- `dcterms:title`: The textual description of the task.
+- `kb:hasStatus`: A link to a resource representing its status (e.g., `kb:StatusOpen`, `kb:StatusCompleted`).
+- `dcterms:source`: A link to the RDF resource representing the source Markdown document.
+- Optionally, other properties like `dcterms:created` (if a creation date can be inferred or is part of the task text) or links to related entities.
+
+## Acceptance Criteria
+
+1.  Standard Markdown todo items (`- [ ]`, `- [x]`, `* [ ]`, `* [X]`) are correctly parsed from document content.
+2.  For each todo item, an RDF resource with `rdf:type kb:ToDoItem` (or equivalent) is generated.
+3.  The `kb:ToDoItem` resource has a `dcterms:title` property containing the exact text of the task.
+4.  The `kb:ToDoItem` resource has a `kb:hasStatus` property linking to `kb:StatusOpen` for `[ ]` tasks and `kb:StatusCompleted` for `[x]` or `[X]` tasks.
+5.  The `kb:ToDoItem` resource is linked to the RDF resource representing its source document via `dcterms:source` (or a similar provenance predicate).
+6.  Extraction is robust to variations in whitespace around brackets.
+
+## Technical Implementation
+
+### Components Involved
+
+| Component                             | Role                                                                                                |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------|
+| Reader & Parser                       | Parses Markdown into a Parsed Document Model, identifying list items and their checkbox state.        |
+| Extractor (Entity & Relationship)     | Specifically identifies todo items from the Parsed Document Model elements and extracts their text and status. |
+| RDF Conversion & Serialization        | Maps the extracted todo item data (text, status, source document link) to RDF triples using the defined `kb:ToDoItem` class and properties. |
+| RDF Triple/Quad Store                 | Stores the generated RDF triples for the todo items.                                                |
+| Initial RDF Vocabulary/Ontology       | Defines `kb:ToDoItem`, `kb:hasStatus`, `kb:StatusOpen`, `kb:StatusCompleted`.                       |
+
+### Data Model Changes
+
+Introduction of new RDF classes and properties:
+-   **Classes**:
+    -   `kb:ToDoItem`: Represents a task or todo item.
+    -   `kb:StatusOpen`: Represents the status of an open task.
+    -   `kb:StatusCompleted`: Represents the status of a completed task.
+-   **Properties**:
+    -   `kb:hasStatus` (domain: `kb:ToDoItem`, range: `kb:StatusOpen` or `kb:StatusCompleted`): Links a task to its status.
+    -   (Standard properties like `dcterms:title`, `dcterms:source`, `rdf:type` will be reused).
+
+**Example RDF (Turtle):**
+```turtle
+@prefix kb: <http://example.org/kb/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<urn:uuid:task-123> a kb:ToDoItem ;
+    dcterms:title "Review ADR-0009" ;
+    kb:hasStatus kb:StatusOpen ;
+    dcterms:source <urn:uuid:document-abc> .
+
+<urn:uuid:task-456> a kb:ToDoItem ;
+    dcterms:title "Update roadmap document" ;
+    kb:hasStatus kb:StatusCompleted ;
+    dcterms:source <urn:uuid:document-xyz> .
+
+kb:StatusOpen a kb:Status .
+kb:StatusCompleted a kb:Status .
+```
+(Note: URIs for tasks, documents, and status instances would be systematically generated).
+
+### Process Flow
+
+1.  **Reader & Parser** processes a Markdown file, creating a Parsed Document Model. This model identifies list items and whether they contain `[ ]` or `[x]`.
+2.  **Orchestrator** passes the Parsed Document Model to the **Extractor**.
+3.  **Extractor** iterates through relevant elements (e.g., list items) in the Parsed Document Model.
+    - If a list item is identified as a todo item (contains `[ ]` or `[x]`), its text and status are extracted.
+    - A unique identifier for the todo item is generated.
+4.  The list of extracted todo items (with text, status, source document ID) is passed to the **RDF Conversion & Serialization** component.
+5.  **RDF Conversion & Serialization** generates RDF triples for each todo item:
+    - Creates a `kb:ToDoItem` resource.
+    - Adds `dcterms:title` with the task text.
+    - Adds `kb:hasStatus` linking to `kb:StatusOpen` or `kb:StatusCompleted`.
+    - Adds `dcterms:source` linking to the source document's RDF resource.
+6.  The generated RDF triples are loaded into the **RDF Triple/Quad Store**.
+
+## Dependencies
+
+| Dependency                             | Type    | Status  | Notes                                                        |
+|----------------------------------------|---------|---------|--------------------------------------------------------------|
+| Markdown Parser to Document Model      | Feature | Planned | Essential for identifying todo structures in Markdown.         |
+| Initial RDF Vocabulary/Ontology Def.   | Feature | Planned | `kb:ToDoItem`, `kb:hasStatus`, etc., must be defined.        |
+| RDF Conversion & Serialization Component | Feature | Planned | Needed to transform extracted data to RDF.                   |
+| RDF Store Setup & Integration          | Feature | Planned | A store must be available to persist the RDF data.           |
+
+## Limitations and Constraints
+
+-   Initial implementation will focus on standard Markdown task syntax (`- [ ]`, `- [x]`). Non-standard variations might not be recognized.
+-   Parsing of dates, priorities, or assignees embedded within the task text (e.g., "@John due:tomorrow !High") is out of scope for the initial version but is a candidate for future enhancement.
+-   Contextual linking to other entities (projects, people) based on text analysis within the todo item is a future enhancement.
+
+## Future Enhancements
+
+-   Parse and model due dates, creation dates, completion dates from task text or surrounding context.
+-   Extract and link assignees or mentioned people/projects (e.g., `@mention`, `[[wikilink]]` within task text).
+-   Support for hierarchical tasks or sub-tasks if identifiable in Markdown.
+-   Allow custom task status beyond open/completed.
+-   Integrate with external task management systems by mapping their task models to/from RDF.
+
+## Related Architecture Decisions
+
+-   [ADR-0009: Knowledge Graph and RDF Store for Enhanced Knowledge Representation](../architecture/decisions/0009-knowledge-graph-rdf-store.md) - This feature is a direct implementation of leveraging the decided RDF architecture for a key data type.


### PR DESCRIPTION
This PR introduces documentation updates to reflect the architectural decision to shift towards a knowledge graph and RDF-based system.

Key changes include:
- New ADR for the decision (docs/architecture/decisions/0009-knowledge-graph-rdf-store.md).
- Updated data flow document (docs/architecture/system-overview/data-flow.md).
- Updated system components document (docs/architecture/system-overview/components.md).
- Updated evolution plan/roadmap (docs/architecture/roadmap/evolution-plan.md).
- An example feature specification for RDF-based todo extraction (docs/features/planned/todo-item-extraction-to-rdf.md).

These documents provide a comprehensive plan and description for the new architecture.