### PR TITLE
Feat: Add integration test for ToDo item RDF extraction

### DIFF
--- a/tests/fixtures/todo_extraction/daily-note-2024-11-07-Thursday.md
+++ b/tests/fixtures/todo_extraction/daily-note-2024-11-07-Thursday.md
@@ -1,0 +1,57 @@
+---
+type: daily-note
+title: "daily-note-2024-11-07-Thursday"
+tags: bydate/2024/11/07, Stellar Solutions Inc.
+created: 2024-11-07T08:54:54-05:00
+---
+# 2024-11-07
+
+## Plan for day
+
+### Tasks
+ - [x] Journaling
+ - [x] Set 30 min timer
+ - [ ] Walk
+ - [x] Medicine
+ - [x] Review Schedule
+ - [ ] Quantum Leap Corp. plan
+
+### Agenda
+
+
+## Log
+
+
+## Nebula Innovations Ltd.
+
+[[Cosmic Ventures LLC CTO Coffee-2024-11-07]]
+
+[[Galaxy Dynamics Co. Discussion-2024-11-07]]
+
+[[Comet Technologies-11-07-Thursday-12:56:10]]
+
+[[Coffee Ops-2024-11-07]]
+
+[[Alex Cipher]]
+[[Blair Quantum11-07]]
+
+
+
+## Topic: Upskilling
+
+
+
+## Daily Summary
+
+### Interactions
+
+### Things done
+
+### Things learned
+
+## Paper notes
+
+### General
+
+
+### Few Words a Day


### PR DESCRIPTION
Closes #34

*   Added [](tests/fixtures/todo_extraction/daily-note-2024-11-07-Thursday.md) as a test fixture.
*   Added a new integration test `test_todo_item_extraction_to_rdf` to [`tests/test_integration.py`](tests/test_integration.py:216) to verify ToDo item extraction to RDF.
*   Confirmed that the existing ToDo extraction logic correctly handles the case covered by the new test, so no changes to the core extraction or RDF conversion logic were necessary.