### PR TITLE
Fix RDF generation not creating output files (Issue #41)

### DIFF
--- a/issue_41_implementation_plan.md
+++ b/issue_41_implementation_plan.md
@@ -1,0 +1,186 @@
+# Implementation Plan for Issue #41: Fix RDF Generation Not Creating Output Files
+
+## Issue Summary
+The RDF generation feature is not creating output files when users specify the `--rdf-output-dir` parameter. The system logs indicate successful RDF generation, but no actual `.ttl` files are created in the specified directory.
+
+## Root Cause Analysis
+
+After analyzing the code, I've identified the following root causes:
+
+1. **Entity Analysis Disabled by Default**: The `analyze_entities` flag in the configuration defaults to `false` (line 26 in `config.py`), preventing named entity extraction from document content.
+
+2. **Limited Entity Sources**: Without entity analysis enabled, only TODO items and WikiLink entities can generate RDF. However, WikiLink entities are not being added to the `doc_metadata.entities` list that the RDF generation logic checks.
+
+3. **Missing WikiLink Entity Conversion**: While WikiLinks are processed and entities are extracted from them (lines 130-136 in `processor.py`), these entities are not added to `doc_metadata.entities`, which is what the RDF generation logic checks (line 317).
+
+4. **No Automatic Entity Analysis Enablement**: When users specify `--rdf-output-dir`, the system doesn't automatically enable entity analysis, leading to empty RDF generation for most documents.
+
+## Implementation Plan
+
+### Phase 1: Fix WikiLink Entity Processing
+
+#### 1.1 Add WikiLink Entities to Document Metadata
+**File**: `src/knowledgebase_processor/processor/processor.py`
+**Changes**:
+- After line 136, add code to extract entities from WikiLinks and add them to `doc_metadata.entities`
+- This ensures WikiLink entities are available for RDF generation
+
+```python
+# After line 136 in processor.py
+# Add WikiLink entities to the document's entity list
+for entity in wikilink_obj.entities:
+    if entity not in doc_metadata.entities:
+        doc_metadata.entities.append(entity)
+```
+
+#### 1.2 Create Unit Tests for WikiLink Entity RDF Generation
+**File**: `tests/processor/test_wikilink_rdf_generation.py` (new file)
+**Tests**:
+- Test that WikiLink entities are added to document metadata
+- Test that RDF is generated for WikiLink entities
+- Test that `.ttl` files are created when WikiLinks contain entities
+
+### Phase 2: Auto-Enable Entity Analysis for RDF Generation
+
+#### 2.1 Modify CLI to Auto-Enable Entity Analysis
+**File**: `src/knowledgebase_processor/cli/main.py`
+**Changes**:
+- In the `process_command` function, check if `rdf_output_dir` is specified
+- If yes, temporarily enable `analyze_entities` in the config
+- Add warning message to inform users
+
+```python
+# In process_command function, after line 440
+if rdf_output_dir_str and not config.analyze_entities:
+    logger_proc.warning(
+        "Entity analysis is disabled but RDF output was requested. "
+        "Automatically enabling entity analysis for this run to generate meaningful RDF output."
+    )
+    config.analyze_entities = True
+    # Reinitialize the processor with updated config
+    kb_processor.processor = Processor(config=config)
+```
+
+#### 2.2 Update Configuration Documentation
+**File**: `src/knowledgebase_processor/config/config.py`
+**Changes**:
+- Update the description of `analyze_entities` to mention its relationship with RDF generation
+
+### Phase 3: Improve RDF Generation Robustness
+
+#### 3.1 Add Directory Creation and Validation
+**File**: `src/knowledgebase_processor/processor/processor.py`
+**Changes**:
+- Before line 310, add code to ensure the RDF output directory exists
+- Add validation to check write permissions
+
+```python
+# Before line 310 in processor.py
+if rdf_output_path and not rdf_output_path.exists():
+    try:
+        rdf_output_path.mkdir(parents=True, exist_ok=True)
+        logger_proc_rdf.info(f"Created RDF output directory: {rdf_output_path}")
+    except Exception as e:
+        logger_proc_rdf.error(f"Failed to create RDF output directory: {e}")
+        return 1
+```
+
+#### 3.2 Enhance Logging and Error Handling
+**File**: `src/knowledgebase_processor/processor/processor.py`
+**Changes**:
+- Add debug logging to show the number of entities found before RDF generation
+- Add try-catch around file writing with detailed error messages
+- Log the absolute path of created files
+
+```python
+# After line 316, before the entity check
+logger_proc_rdf.debug(f"Document {doc.path} has {len(doc.metadata.entities) if doc.metadata and doc.metadata.entities else 0} entities")
+
+# Modify line 384 to use absolute path
+logger_proc_rdf.info(f"Saved RDF for {Path(doc.path).name} to {output_file_path.absolute()}")
+```
+
+### Phase 4: Add Progress Reporting
+
+#### 4.1 Implement RDF Generation Summary
+**File**: `src/knowledgebase_processor/processor/processor.py`
+**Changes**:
+- Track statistics during RDF generation
+- Report summary at the end
+
+```python
+# Add before the RDF generation loop
+rdf_stats = {
+    'files_processed': 0,
+    'files_with_entities': 0,
+    'total_entities': 0,
+    'total_todos': 0,
+    'files_generated': 0,
+    'errors': 0
+}
+
+# Update stats during processing and report at the end
+```
+
+### Phase 5: Testing Strategy
+
+#### 5.1 Unit Tests
+- Test RDF generation with entity analysis disabled (should process TODOs and WikiLinks)
+- Test RDF generation with entity analysis enabled  
+- Test file creation and error handling
+- Test empty document handling
+
+#### 5.2 Integration Tests
+- Test full pipeline with sample documents containing:
+  - TODO items only
+  - WikiLinks with recognizable entities
+  - Named entities in text (with entity analysis enabled)
+  - Mixed content
+- Verify actual file creation on disk
+
+#### 5.3 Manual Testing Checklist
+1. Run with `--rdf-output-dir` and default config (entity analysis disabled)
+2. Verify TODOs and WikiLink entities generate RDF
+3. Run with `--rdf-output-dir` and entity analysis enabled
+4. Verify all entity types generate RDF
+5. Test with non-existent output directory
+6. Test with read-only output directory (should fail gracefully)
+
+## Implementation Order
+
+1. **Immediate Fix** (Phase 1): Fix WikiLink entity processing to ensure some RDF generation works without config changes
+2. **User Experience** (Phase 2): Auto-enable entity analysis when RDF output is requested
+3. **Robustness** (Phase 3): Improve error handling and directory management
+4. **Visibility** (Phase 4): Add progress reporting for better user feedback
+5. **Quality Assurance** (Phase 5): Comprehensive testing
+
+## Success Criteria
+
+1. RDF files are created when `--rdf-output-dir` is specified
+2. WikiLink entities and TODO items generate RDF without enabling entity analysis
+3. Clear user feedback about what entities were found and processed
+4. Graceful error handling with actionable error messages
+5. All existing tests pass, and new tests provide good coverage
+
+## Estimated Effort
+
+- Phase 1: 2-3 hours (core fix + tests)
+- Phase 2: 1-2 hours (auto-enable + documentation)
+- Phase 3: 2-3 hours (robustness improvements)
+- Phase 4: 1-2 hours (progress reporting)
+- Phase 5: 3-4 hours (comprehensive testing)
+
+**Total: 9-14 hours**
+
+## Risk Mitigation
+
+1. **Backward Compatibility**: Changes should not break existing functionality
+2. **Performance**: Entity analysis auto-enablement may slow processing - add warning
+3. **Configuration**: Document the auto-enable behavior clearly
+
+## Follow-up Improvements
+
+1. Add `--dry-run` option to preview what RDF would be generated
+2. Add `--force-entity-analysis` flag for explicit control
+3. Consider making entity analysis default to `true` in a future major version
+4. Add support for custom entity extractors via plugins

--- a/src/knowledgebase_processor/cli/main.py
+++ b/src/knowledgebase_processor/cli/main.py
@@ -438,6 +438,17 @@ def process_command(args: argparse.Namespace, config, kb_processor: KnowledgeBas
     logger_proc.info(f"Processing files matching pattern: {pattern} in knowledge base: {config.knowledge_base_path}")
     if rdf_output_dir_str:
         logger_proc.info(f"RDF output directory specified: {rdf_output_dir_str}")
+        
+        # Auto-enable entity analysis when RDF output is requested but analysis is disabled
+        if not config.analyze_entities:
+            logger_proc.warning(
+                "Entity analysis is disabled but RDF output was requested. "
+                "Automatically enabling entity analysis for this run to generate meaningful RDF output."
+            )
+            config.analyze_entities = True
+            # Reinitialize the processor with updated config
+            from knowledgebase_processor.processor.processor import Processor
+            kb_processor.processor = Processor(config=config)
 
     # The kb_processor instance contains the reader, metadata_store, and the processor (which has the new method)
     # config.knowledge_base_path is a string, convert to Path for the method

--- a/src/knowledgebase_processor/cli/main.py
+++ b/src/knowledgebase_processor/cli/main.py
@@ -448,7 +448,36 @@ def process_command(args: argparse.Namespace, config, kb_processor: KnowledgeBas
             config.analyze_entities = True
             # Reinitialize the processor with updated config
             from knowledgebase_processor.processor.processor import Processor
+            from knowledgebase_processor.extractor.markdown import MarkdownExtractor
+            from knowledgebase_processor.extractor.frontmatter import FrontmatterExtractor
+            from knowledgebase_processor.extractor.heading_section import HeadingSectionExtractor
+            from knowledgebase_processor.extractor.link_reference import LinkReferenceExtractor
+            from knowledgebase_processor.extractor.code_quote import CodeQuoteExtractor
+            from knowledgebase_processor.extractor.todo_item import TodoItemExtractor
+            from knowledgebase_processor.extractor.tags import TagExtractor
+            from knowledgebase_processor.extractor.list_table import ListTableExtractor
+            from knowledgebase_processor.extractor.wikilink_extractor import WikiLinkExtractor
+            from knowledgebase_processor.analyzer.topics import TopicAnalyzer
+            from knowledgebase_processor.enricher.relationships import RelationshipEnricher
+            
             kb_processor.processor = Processor(config=config)
+            
+            # Re-register all extractors
+            kb_processor.processor.register_extractor(MarkdownExtractor())
+            kb_processor.processor.register_extractor(FrontmatterExtractor())
+            kb_processor.processor.register_extractor(HeadingSectionExtractor())
+            kb_processor.processor.register_extractor(LinkReferenceExtractor())
+            kb_processor.processor.register_extractor(CodeQuoteExtractor())
+            kb_processor.processor.register_extractor(TodoItemExtractor())
+            kb_processor.processor.register_extractor(TagExtractor())
+            kb_processor.processor.register_extractor(ListTableExtractor())
+            kb_processor.processor.register_extractor(WikiLinkExtractor())
+            
+            # Re-register analyzers
+            kb_processor.processor.register_analyzer(TopicAnalyzer())
+            
+            # Re-register enrichers
+            kb_processor.processor.register_enricher(RelationshipEnricher())
 
     # The kb_processor instance contains the reader, metadata_store, and the processor (which has the new method)
     # config.knowledge_base_path is a string, convert to Path for the method

--- a/src/knowledgebase_processor/extractor/todo_item.py
+++ b/src/knowledgebase_processor/extractor/todo_item.py
@@ -20,8 +20,8 @@ class TodoItemExtractor(BaseExtractor):
     
     def __init__(self):
         """Initialize the TodoItemExtractor."""
-        # Regex pattern for todo items
-        self.todo_pattern = re.compile(r'^-\s+\[([ xX])\]\s+(.+)$', re.MULTILINE)
+        # Regex pattern for todo items - allows optional leading whitespace
+        self.todo_pattern = re.compile(r'^\s*-\s+\[([ xX])\]\s+(.+)$', re.MULTILINE)
     
     def extract(self, document: Document) -> List[ContentElement]:
         """Extract todo items from a document.

--- a/src/knowledgebase_processor/processor/processor.py
+++ b/src/knowledgebase_processor/processor/processor.py
@@ -134,6 +134,11 @@ class Processor:
                 raw_entities = self.entity_recognizer.analyze_text_for_entities(text_for_analysis)
                 wikilink_obj.entities = raw_entities # entities are List[ModelExtractedEntity]
                 doc_metadata.wikilinks.append(wikilink_obj)
+                
+                # Add WikiLink entities to the document's entity list for RDF generation
+                for entity in raw_entities:
+                    if entity not in doc_metadata.entities:
+                        doc_metadata.entities.append(entity)
         
         # Populate doc_metadata.structure
         doc_metadata.structure = {
@@ -307,12 +312,25 @@ class Processor:
             count = len(processed_documents)
             logger_proc_rdf.info(f"Processed and stored metadata for {count} documents.")
 
+            # Ensure RDF output directory exists before generating RDF
+            if rdf_output_path and not rdf_output_path.exists():
+                try:
+                    rdf_output_path.mkdir(parents=True, exist_ok=True)
+                    logger_proc_rdf.info(f"Created RDF output directory: {rdf_output_path}")
+                except Exception as e:
+                    logger_proc_rdf.error(f"Failed to create RDF output directory: {e}")
+                    return 1
+
             if rdf_converter and rdf_output_path and processed_documents:
                 logger_proc_rdf.info(f"Starting RDF generation for {count} documents...")
                 for doc_idx, doc in enumerate(processed_documents):
                     if not doc.path: # doc.path should be relative string path from Document model
                         logger_proc_rdf.warning(f"Document at index {doc_idx} missing source_path, skipping RDF generation.")
                         continue
+
+                    # Log debug information about entities found
+                    entity_count = len(doc.metadata.entities) if doc.metadata and doc.metadata.entities else 0
+                    logger_proc_rdf.debug(f"Document {doc.path} has {entity_count} entities")
 
                     if not doc.metadata or not doc.metadata.entities:
                         logger_proc_rdf.debug(f"No entities to convert for document: {doc.path}")
@@ -381,7 +399,7 @@ class Processor:
                         output_file_path = rdf_output_path / output_filename
                         try:
                             doc_graph.serialize(destination=str(output_file_path), format="turtle")
-                            logger_proc_rdf.info(f"Saved RDF for {Path(doc.path).name} to {output_file_path}")
+                            logger_proc_rdf.info(f"Saved RDF for {Path(doc.path).name} to {output_file_path.absolute()}")
                         except Exception as e_ser:
                             logger_proc_rdf.error(f"Error serializing RDF for {Path(doc.path).name} to {output_file_path}: {e_ser}", exc_info=True)
                     else:

--- a/src/knowledgebase_processor/processor/processor.py
+++ b/src/knowledgebase_processor/processor/processor.py
@@ -323,18 +323,39 @@ class Processor:
 
             if rdf_converter and rdf_output_path and processed_documents:
                 logger_proc_rdf.info(f"Starting RDF generation for {count} documents...")
+                
+                # Initialize statistics tracking
+                rdf_stats = {
+                    'files_processed': 0,
+                    'files_with_entities': 0,
+                    'total_entities': 0,
+                    'total_todos': 0,
+                    'files_generated': 0,
+                    'errors': 0
+                }
+                
                 for doc_idx, doc in enumerate(processed_documents):
+                    rdf_stats['files_processed'] += 1
+                    
                     if not doc.path: # doc.path should be relative string path from Document model
                         logger_proc_rdf.warning(f"Document at index {doc_idx} missing source_path, skipping RDF generation.")
+                        rdf_stats['errors'] += 1
                         continue
 
                     # Log debug information about entities found
                     entity_count = len(doc.metadata.entities) if doc.metadata and doc.metadata.entities else 0
                     logger_proc_rdf.debug(f"Document {doc.path} has {entity_count} entities")
+                    
+                    # Count TODO items
+                    todo_count = sum(1 for element in doc.elements if element.element_type == "todo_item")
+                    rdf_stats['total_todos'] += todo_count
 
                     if not doc.metadata or not doc.metadata.entities:
                         logger_proc_rdf.debug(f"No entities to convert for document: {doc.path}")
                         continue
+                    
+                    rdf_stats['files_with_entities'] += 1
+                    rdf_stats['total_entities'] += entity_count
 
                     doc_graph = Graph()
                     doc_graph.bind("kb", KB)
@@ -400,10 +421,22 @@ class Processor:
                         try:
                             doc_graph.serialize(destination=str(output_file_path), format="turtle")
                             logger_proc_rdf.info(f"Saved RDF for {Path(doc.path).name} to {output_file_path.absolute()}")
+                            rdf_stats['files_generated'] += 1
                         except Exception as e_ser:
                             logger_proc_rdf.error(f"Error serializing RDF for {Path(doc.path).name} to {output_file_path}: {e_ser}", exc_info=True)
+                            rdf_stats['errors'] += 1
                     else:
                         logger_proc_rdf.info(f"No RDF triples generated for document: {doc.path}")
+                
+                # Report RDF generation summary
+                logger_proc_rdf.info(
+                    f"RDF Generation Summary: "
+                    f"Processed {rdf_stats['files_processed']} files, "
+                    f"{rdf_stats['files_with_entities']} had entities, "
+                    f"found {rdf_stats['total_entities']} entities and {rdf_stats['total_todos']} TODOs, "
+                    f"generated {rdf_stats['files_generated']} RDF files"
+                    + (f", {rdf_stats['errors']} errors" if rdf_stats['errors'] > 0 else "")
+                )
             return 0
         except Exception as e:
             logger_proc_rdf.error(f"An error occurred during processing or RDF generation: {e}", exc_info=True)

--- a/tests/extractor/test_todo_item_extractor.py
+++ b/tests/extractor/test_todo_item_extractor.py
@@ -136,6 +136,43 @@ This is a test document with no todo items.
         self.assertEqual(elements[0].parent_id, section_id)
         self.assertEqual(elements[1].parent_id, section_id)
     
+    def test_extract_todos_with_leading_whitespace(self):
+        """Test extracting todo items with leading whitespace."""
+        content = """# Test Document
+        
+ - [ ] Single space indent
+  - [x] Two space indent
+    - [ ] Four space indent
+	- [x] Tab indent
+- [ ] No indent
+"""
+        document = Document(path="test.md", content=content, title="Test")
+        elements = self.extractor.extract(document)
+        
+        # We should have 5 todo items
+        self.assertEqual(len(elements), 5)
+        
+        # Check all are TodoItem instances
+        for element in elements:
+            self.assertIsInstance(element, TodoItem)
+            self.assertEqual(element.element_type, "todo_item")
+        
+        # Check specific items
+        self.assertEqual(elements[0].text, "Single space indent")
+        self.assertFalse(elements[0].is_checked)
+        
+        self.assertEqual(elements[1].text, "Two space indent")
+        self.assertTrue(elements[1].is_checked)
+        
+        self.assertEqual(elements[2].text, "Four space indent")
+        self.assertFalse(elements[2].is_checked)
+        
+        self.assertEqual(elements[3].text, "Tab indent")
+        self.assertTrue(elements[3].is_checked)
+        
+        self.assertEqual(elements[4].text, "No indent")
+        self.assertFalse(elements[4].is_checked)
+    
     def test_integration_with_processor(self):
         """Test integration with the processor."""
         from knowledgebase_processor.processor.processor import Processor

--- a/tests/processor/test_wikilink_rdf_generation.py
+++ b/tests/processor/test_wikilink_rdf_generation.py
@@ -1,0 +1,248 @@
+"""
+Test WikiLink entity processing for RDF generation.
+
+This module tests that WikiLink entities are properly added to document metadata
+and that RDF files are generated when WikiLinks contain entities.
+"""
+import unittest
+from unittest.mock import Mock, patch
+from pathlib import Path
+import tempfile
+import shutil
+
+from knowledgebase_processor.models.content import Document
+from knowledgebase_processor.models.metadata import DocumentMetadata
+from knowledgebase_processor.models.links import WikiLink
+from knowledgebase_processor.models.metadata import ExtractedEntity as ModelExtractedEntity
+from knowledgebase_processor.processor.processor import Processor
+from knowledgebase_processor.config.config import Config
+
+
+class TestWikiLinkRDFGeneration(unittest.TestCase):
+    """Test WikiLink entity processing for RDF generation."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir)
+        
+        # Create test config
+        self.config = Config(
+            knowledge_base_path=self.temp_dir,
+            metadata_store_path=str(Path(self.temp_dir) / "metadata"),
+            analyze_entities=False  # Test with entity analysis disabled
+        )
+        
+        # Create processor instance
+        self.processor = Processor(config=self.config)
+
+    def test_wikilink_entities_added_to_document_metadata(self):
+        """Test that WikiLink entities are added to document metadata."""
+        # Create a mock document with a WikiLink element
+        wikilink = WikiLink(
+            content="[[John Doe]]",
+            element_type="wikilink",
+            position={"start": 0, "end": 11},
+            target_page="John Doe",
+            display_text="John Doe"
+        )
+        
+        # Create mock entities that would be extracted from the WikiLink
+        mock_entity = ModelExtractedEntity(
+            text="John Doe",
+            label="PERSON",
+            start_char=0,
+            end_char=8,
+            confidence=0.95
+        )
+        
+        document = Document(
+            path="test.md",
+            title="Test Document",
+            content="[[John Doe]] is a person.",
+            elements=[wikilink]
+        )
+        
+        # Mock the entity recognizer to return our mock entity
+        with patch.object(self.processor.entity_recognizer, 'analyze_text_for_entities') as mock_analyze:
+            mock_analyze.return_value = [mock_entity]
+            
+            # Process the document
+            processed_doc = self.processor.process_document(document)
+            
+            # Check that the WikiLink entity was added to document metadata
+            self.assertIsNotNone(processed_doc.metadata)
+            self.assertEqual(len(processed_doc.metadata.entities), 1)
+            self.assertEqual(processed_doc.metadata.entities[0], mock_entity)
+            self.assertEqual(len(processed_doc.metadata.wikilinks), 1)
+            self.assertEqual(processed_doc.metadata.wikilinks[0].entities, [mock_entity])
+
+    def test_wikilink_rdf_generation_without_entity_analysis(self):
+        """Test that RDF is generated for WikiLink entities without enabling entity analysis."""
+        # Create temporary RDF output directory
+        rdf_output_dir = Path(self.temp_dir) / "rdf_output"
+        
+        # Create a document with WikiLink
+        wikilink = WikiLink(
+            content="[[Jane Smith]]",
+            element_type="wikilink",
+            position={"start": 0, "end": 14},
+            target_page="Jane Smith",
+            display_text="Jane Smith"
+        )
+        
+        mock_entity = ModelExtractedEntity(
+            text="Jane Smith",
+            label="PERSON",
+            start_char=0,
+            end_char=10,
+            confidence=0.90
+        )
+        
+        document = Document(
+            path="wikilink_test.md",
+            title="WikiLink Test",
+            content="[[Jane Smith]] works here.",
+            elements=[wikilink]
+        )
+        
+        # Mock reader and metadata store
+        mock_reader = Mock()
+        mock_reader.read_all.return_value = [document]
+        
+        mock_metadata_store = Mock()
+        
+        # Mock the entity recognizer
+        with patch.object(self.processor.entity_recognizer, 'analyze_text_for_entities') as mock_analyze:
+            mock_analyze.return_value = [mock_entity]
+            
+            # Process and generate RDF
+            result = self.processor.process_and_generate_rdf(
+                reader=mock_reader,
+                metadata_store=mock_metadata_store,
+                pattern="*.md",
+                knowledge_base_path=Path(self.temp_dir),
+                rdf_output_dir_str=str(rdf_output_dir)
+            )
+            
+            # Check that processing succeeded
+            self.assertEqual(result, 0)
+            
+            # Check that RDF file was created
+            expected_rdf_file = rdf_output_dir / "wikilink_test.ttl"
+            self.assertTrue(expected_rdf_file.exists())
+            
+            # Check that the file has content
+            with open(expected_rdf_file, 'r') as f:
+                rdf_content = f.read()
+                self.assertIn("Jane Smith", rdf_content)
+                
+    def test_multiple_wikilink_entities_in_document(self):
+        """Test processing of multiple WikiLink entities in a single document."""
+        # Create WikiLinks with different entity types
+        person_wikilink = WikiLink(
+            content="[[Alice Wonder]]",
+            element_type="wikilink",
+            position={"start": 0, "end": 15},
+            target_page="Alice Wonder",
+            display_text="Alice Wonder"
+        )
+        
+        org_wikilink = WikiLink(
+            content="[[ACME Corp]]",
+            element_type="wikilink",
+            position={"start": 30, "end": 43},
+            target_page="ACME Corp",
+            display_text="ACME Corp"
+        )
+        
+        person_entity = ModelExtractedEntity(
+            text="Alice Wonder",
+            label="PERSON",
+            start_char=0,
+            end_char=12,
+            confidence=0.95
+        )
+        
+        org_entity = ModelExtractedEntity(
+            text="ACME Corp",
+            label="ORG",
+            start_char=0,
+            end_char=9,
+            confidence=0.90
+        )
+        
+        document = Document(
+            path="multi_wikilink.md",
+            title="Multiple WikiLinks",
+            content="[[Alice Wonder]] works at [[ACME Corp]].",
+            elements=[person_wikilink, org_wikilink]
+        )
+        
+        # Mock entity recognizer to return different entities for different texts
+        def mock_analyze_side_effect(text):
+            if text == "Alice Wonder":
+                return [person_entity]
+            elif text == "ACME Corp":
+                return [org_entity]
+            return []
+        
+        with patch.object(self.processor.entity_recognizer, 'analyze_text_for_entities') as mock_analyze:
+            mock_analyze.side_effect = mock_analyze_side_effect
+            
+            # Process the document
+            processed_doc = self.processor.process_document(document)
+            
+            # Check that both entities were added to document metadata
+            self.assertEqual(len(processed_doc.metadata.entities), 2)
+            entity_texts = [e.text for e in processed_doc.metadata.entities]
+            self.assertIn("Alice Wonder", entity_texts)
+            self.assertIn("ACME Corp", entity_texts)
+
+    def test_duplicate_wikilink_entities_not_duplicated(self):
+        """Test that duplicate WikiLink entities are not added multiple times."""
+        # Create two WikiLinks with the same entity
+        wikilink1 = WikiLink(
+            content="[[Bob Builder]]",
+            element_type="wikilink",
+            position={"start": 0, "end": 15},
+            target_page="Bob Builder",
+            display_text="Bob Builder"
+        )
+        
+        wikilink2 = WikiLink(
+            content="[[Bob Builder]]",
+            element_type="wikilink",
+            position={"start": 30, "end": 45},
+            target_page="Bob Builder",
+            display_text="Bob Builder"
+        )
+        
+        mock_entity = ModelExtractedEntity(
+            text="Bob Builder",
+            label="PERSON",
+            start_char=0,
+            end_char=11,
+            confidence=0.95
+        )
+        
+        document = Document(
+            path="duplicate_wikilink.md",
+            title="Duplicate WikiLinks",
+            content="[[Bob Builder]] and [[Bob Builder]] again.",
+            elements=[wikilink1, wikilink2]
+        )
+        
+        with patch.object(self.processor.entity_recognizer, 'analyze_text_for_entities') as mock_analyze:
+            mock_analyze.return_value = [mock_entity]
+            
+            # Process the document
+            processed_doc = self.processor.process_document(document)
+            
+            # Check that only one entity was added despite two WikiLinks
+            self.assertEqual(len(processed_doc.metadata.entities), 1)
+            self.assertEqual(processed_doc.metadata.entities[0].text, "Bob Builder")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes issue #41 where RDF generation was not creating output files when users specified the `--rdf-output-dir` parameter.

## Changes Made

### Phase 1: Fix WikiLink Entity Processing
- ✅ **WikiLink entities are now added to document metadata** - WikiLink entities are properly extracted and added to `doc_metadata.entities` for RDF generation
- ✅ **Comprehensive unit tests** - Added `test_wikilink_rdf_generation.py` with 4 test cases covering various scenarios

### Phase 2: Auto-Enable Entity Analysis for RDF Generation
- ✅ **Auto-enable entity analysis** - When `--rdf-output-dir` is specified but entity analysis is disabled, the system automatically enables it with a warning message
- ✅ **User-friendly messaging** - Clear warning explains why entity analysis is being enabled

### Phase 3: Improve RDF Generation Robustness
- ✅ **Directory creation and validation** - RDF output directory is automatically created if it doesn't exist
- ✅ **Enhanced error handling** - Better exception handling with detailed error messages
- ✅ **Improved logging** - Debug logging shows entity counts and absolute file paths

### Phase 4: Add Progress Reporting
- ✅ **Statistics tracking** - Track files processed, entities found, TODOs, files generated, and errors
- ✅ **Summary reporting** - Detailed summary at end of RDF generation process

## Root Causes Fixed

1. **Entity analysis disabled by default** - Now auto-enabled when RDF output requested
2. **WikiLink entities not in entity list** - WikiLink entities now properly added to document metadata
3. **Missing directory creation** - Output directories automatically created
4. **Poor user feedback** - Enhanced logging and statistics provide clear visibility

## Testing

- ✅ All existing tests pass (129 tests, 25 skipped)
- ✅ New WikiLink RDF generation tests pass (4 new tests)
- ✅ Verified RDF file creation with WikiLinks
- ✅ Verified auto-enablement of entity analysis
- ✅ Verified statistics and progress reporting

## Expected Impact

- Users can now successfully generate RDF files using `--rdf-output-dir`
- WikiLink entities are processed even without enabling entity analysis
- Clear feedback about processing results through statistics
- Better error handling and user experience

Closes #41