### PR TITLE
feat: Implement SPARQL upsert functionality to prevent duplicate triples

### DIFF
--- a/src/knowledgebase_processor/services/orchestrator.py
+++ b/src/knowledgebase_processor/services/orchestrator.py
@@ -431,6 +431,7 @@ class OrchestratorService:
         username: Optional[str] = None,
         password: Optional[str] = None,
         clear_first: bool = False,
+        upsert: bool = True,
         callback: Optional[callable] = None
     ) -> Dict[str, Any]:
         """Sync knowledge base to SPARQL endpoint.
@@ -441,6 +442,7 @@ class OrchestratorService:
             username: Username for authentication
             password: Password for authentication
             clear_first: Clear existing data first
+            upsert: Use upsert to avoid duplicates (default: True)
             callback: Progress callback
             
         Returns:
@@ -472,7 +474,8 @@ class OrchestratorService:
                 endpoint_url=endpoint_url,
                 cleanup=True,
                 username=username,
-                password=password
+                password=password,
+                upsert=upsert
             )
             
             sync_time = time.time() - start_time

--- a/src/knowledgebase_processor/services/processing_service.py
+++ b/src/knowledgebase_processor/services/processing_service.py
@@ -72,6 +72,7 @@ class ProcessingService:
         cleanup: bool = False,
         username: Optional[str] = None,
         password: Optional[str] = None,
+        upsert: bool = False,
     ) -> int:
         """
         Orchestrate processing and loading: process documents to RDF, load into SPARQL endpoint, and optionally clean up.
@@ -127,11 +128,14 @@ class ProcessingService:
                         update_endpoint_url=endpoint_url,
                         username=username,
                         password=password,
+                        upsert=upsert,
                     )
-                    logger.info(f"Loaded RDF file: {rdf_file}")
+                    operation = "Upserted" if upsert else "Loaded"
+                    logger.info(f"{operation} RDF file: {rdf_file}")
                     successes += 1
                 except Exception as e:
-                    logger.error(f"Failed to load {rdf_file}: {e}")
+                    operation = "upsert" if upsert else "load"
+                    logger.error(f"Failed to {operation} {rdf_file}: {e}")
                     errors.append((str(rdf_file), str(e)))
 
             logger.info(


### PR DESCRIPTION
## Summary

This PR implements comprehensive upsert functionality for SPARQL sync operations to resolve the issue of duplicate triples being created in Fuseki. The implementation uses document-level DELETE/INSERT patterns to ensure data consistency while preventing duplicates.

### Key Features

- **🔄 Document-level upserts**: Removes all existing triples associated with documents before inserting new data
- **🎛️ CLI control**: New `--upsert/--no-upsert` flag (defaults to upsert enabled)  
- **⚡ Fuseki compatibility**: Fixed VALUES clause issues by using individual DELETE queries
- **🔗 Cross-document references**: Maintains entity relationships across documents without duplicates
- **📊 Progress indication**: Shows upsert mode status in sync UI with warnings when disabled

### Technical Implementation

**Core SPARQL Interface Changes:**
- Added `upsert_data()` method implementing DELETE/INSERT pattern
- Added `_extract_document_uris()` to identify documents in RDF graphs
- Added `_delete_document_data()` for existing data removal
- Enhanced `load_file()` with upsert parameter

**Service Layer Updates:**
- Propagated upsert parameter through all service layers
- Updated batch processing to support upsert mode
- Added comprehensive logging for upsert operations

**CLI Enhancement:**
- Added `--upsert/--no-upsert` flag with sensible defaults
- Enhanced progress display with mode indicators
- Added user warnings when upsert is disabled

### Problem Solved

Before this fix, running `kb sync` multiple times would create duplicate triples in Fuseki for entities that appeared across multiple documents. The upsert mechanism now:

1. **Extracts document URIs** from RDF being synced
2. **Deletes existing data** for those documents (including cross-references)
3. **Inserts new data** cleanly without duplicates

### Testing Results

✅ **Upsert mode (default)**: No duplicate triples created  
✅ **Non-upsert mode**: Works as before with warning  
✅ **Fuseki compatibility**: VALUES clause issue resolved  
✅ **Cross-document entities**: Proper handling without duplicates  
✅ **Performance**: Efficient document-level operations  

### Usage Examples

```bash
# Default behavior - upsert enabled
kb sync

# Explicitly enable upsert  
kb sync --upsert

# Disable upsert (may create duplicates)
kb sync --no-upsert

# Use with other sync options
kb sync --endpoint http://localhost:3030/kb --upsert --batch-size 500
```

## Test plan

- [x] Test sync with upsert enabled (default behavior)
- [x] Test sync with upsert disabled (--no-upsert flag)
- [x] Verify no duplicate triples are created with multiple sync runs
- [x] Confirm SPARQL VALUES clause compatibility with Fuseki
- [x] Test cross-document entity references are maintained
- [x] Verify CLI warnings and progress indicators work correctly
- [x] Test with sample knowledge base data from different document types

🤖 Generated with [Claude Code](https://claude.ai/code)