### PR TITLE
Add kb publish command with unified workflow and file watching

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1661,6 +1661,45 @@ files = [
 colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\" and python_version >= \"3.7\""}
 
 [[package]]
+name = "watchdog"
+version = "3.0.0"
+description = "Filesystem events monitoring"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:336adfc6f5cc4e037d52db31194f7581ff744b67382eb6021c868322e32eef41"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a70a8dcde91be523c35b2bf96196edc5730edb347e374c7de7cd20c43ed95397"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:adfdeab2da79ea2f76f87eb42a3ab1966a5313e5a69a0213a3cc06ef692b0e96"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b57a1e730af3156d13b7fdddfc23dea6487fceca29fc75c5a868beed29177ae"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7ade88d0d778b1b222adebcc0927428f883db07017618a5e684fd03b83342bd9"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7e447d172af52ad204d19982739aa2346245cc5ba6f579d16dac4bfec226d2e7"},
+    {file = "watchdog-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9fac43a7466eb73e64a9940ac9ed6369baa39b3bf221ae23493a9ec4d0022674"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8ae9cda41fa114e28faf86cb137d751a17ffd0316d1c34ccf2235e8a84365c7f"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25f70b4aa53bd743729c7475d7ec41093a580528b100e9a8c5b5efe8899592fc"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4f94069eb16657d2c6faada4624c39464f65c05606af50bb7902e036e3219be3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7c5f84b5194c24dd573fa6472685b2a27cc5a17fe5f7b6fd40345378ca6812e3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3aa7f6a12e831ddfe78cdd4f8996af9cf334fd6346531b16cec61c3b3c0d8da0"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:233b5817932685d39a7896b1090353fc8efc1ef99c9c054e46c8002561252fb8"},
+    {file = "watchdog-3.0.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:13bbbb462ee42ec3c5723e1205be8ced776f05b100e4737518c67c8325cf6100"},
+    {file = "watchdog-3.0.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8f3ceecd20d71067c7fd4c9e832d4e22584318983cabc013dbf3f70ea95de346"},
+    {file = "watchdog-3.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c9d8c8ec7efb887333cf71e328e39cffbf771d8f8f95d308ea4125bf5f90ba64"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0e06ab8858a76e1219e68c7573dfeba9dd1c0219476c5a44d5333b01d7e1743a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:d00e6be486affb5781468457b21a6cbe848c33ef43f9ea4a73b4882e5f188a44"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:c07253088265c363d1ddf4b3cdb808d59a0468ecd017770ed716991620b8f77a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:5113334cf8cf0ac8cd45e1f8309a603291b614191c9add34d33075727a967709"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:51f90f73b4697bac9c9a78394c3acbbd331ccd3655c11be1a15ae6fe289a8c83"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:ba07e92756c97e3aca0912b5cbc4e5ad802f4557212788e72a72a47ff376950d"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d429c2430c93b7903914e4db9a966c7f2b068dd2ebdd2fa9b9ce094c7d459f33"},
+    {file = "watchdog-3.0.0-py3-none-win32.whl", hash = "sha256:3ed7c71a9dccfe838c2f0b6314ed0d9b22e77d268c67e015450a29036a81f60f"},
+    {file = "watchdog-3.0.0-py3-none-win_amd64.whl", hash = "sha256:4c9956d27be0bb08fc5f30d9d0179a855436e655f046d288e2bcc11adfae893c"},
+    {file = "watchdog-3.0.0-py3-none-win_ia64.whl", hash = "sha256:5d9f3a10e02d7371cd929b5d8f11e87d4bad890212ed3901f9b4d68767bee759"},
+    {file = "watchdog-3.0.0.tar.gz", hash = "sha256:4d98a320595da7a7c5a18fc48cb633c2e73cda78f93cac2ef42d42bf609a33f9"},
+]
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
+
+[[package]]
 name = "weasel"
 version = "0.4.1"
 description = "Weasel: A small and easy workflow system"
@@ -1789,4 +1828,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "92b93632068de684ff6086c4cb3dec2b47f11a3999c9d50f40b2ec877ea73844"
+content-hash = "6907996b29698508be90f41cf9e274f1f1a37c7e2fb04cb38142ce9a5a6acea4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ spacy = "^3.7.0"
 rdflib = "^7.0.0"
 click = "^8.1.0"
 rich = "^13.7.0"
+watchdog = "^3.0.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.0"

--- a/src/knowledgebase_processor/cli_v2/commands/__init__.py
+++ b/src/knowledgebase_processor/cli_v2/commands/__init__.py
@@ -1,1 +1,19 @@
-"""Command modules for CLI v2."""
+"""CLI commands package."""
+
+from .init import init_cmd
+from .scan import scan_cmd
+from .search import search_cmd
+from .sync import sync_cmd
+from .publish import publish_cmd
+from .status import status_cmd
+from .config import config_cmd
+
+__all__ = [
+    'init_cmd',
+    'scan_cmd', 
+    'search_cmd',
+    'sync_cmd',
+    'publish_cmd',
+    'status_cmd',
+    'config_cmd'
+]

--- a/src/knowledgebase_processor/cli_v2/commands/publish.py
+++ b/src/knowledgebase_processor/cli_v2/commands/publish.py
@@ -1,0 +1,320 @@
+"""Publish command - Unified process + sync workflow."""
+
+import click
+from pathlib import Path
+from typing import Optional
+import time
+import asyncio
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+from ..utils import console, print_success, print_error, print_info, print_warning, create_progress, format_duration
+from ...services.orchestrator import OrchestratorService
+
+
+class KnowledgeBaseHandler(FileSystemEventHandler):
+    """File system event handler for knowledge base files."""
+    
+    def __init__(self, orchestrator: OrchestratorService, sync_config: dict, debounce_seconds: float = 2.0):
+        super().__init__()
+        self.orchestrator = orchestrator
+        self.sync_config = sync_config
+        self.debounce_seconds = debounce_seconds
+        self.pending_changes = set()
+        self.last_change_time = 0
+        
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+            
+        file_path = Path(event.src_path)
+        
+        # Check if file matches our patterns
+        config = self.orchestrator.get_project_config()
+        if config and any(file_path.match(pattern) for pattern in config.file_patterns):
+            self.pending_changes.add(file_path)
+            self.last_change_time = time.time()
+    
+    def on_created(self, event):
+        self.on_modified(event)
+    
+    def on_deleted(self, event):
+        if not event.is_directory:
+            file_path = Path(event.src_path)
+            self.pending_changes.add(file_path)
+            self.last_change_time = time.time()
+    
+    def should_process_changes(self) -> bool:
+        """Check if enough time has passed since last change (debouncing)."""
+        return (
+            self.pending_changes and 
+            time.time() - self.last_change_time >= self.debounce_seconds
+        )
+    
+    def process_pending_changes(self):
+        """Process all pending file changes."""
+        if not self.pending_changes:
+            return
+            
+        console.print(f"\n📝 [subheading]Processing {len(self.pending_changes)} changed files...[/subheading]")
+        
+        try:
+            # Process documents
+            result = self.orchestrator.process_documents(
+                patterns=None,  # Use default patterns
+                force=False     # Only process changed files
+            )
+            
+            if result.files_processed > 0:
+                console.print(f"  ✅ Processed {result.files_processed} files")
+                
+                # Sync to SPARQL
+                sync_result = self.orchestrator.sync_to_sparql(**self.sync_config)
+                
+                if sync_result.get('success'):
+                    files_synced = sync_result.get('files_synced', 0)
+                    transfer_rate = sync_result.get('transfer_rate', '0 KB/s')
+                    console.print(f"  🔄 Synced {files_synced} files ({transfer_rate})")
+                    print_success("Knowledge base updated successfully!")
+                else:
+                    print_error(f"Sync failed: {sync_result.get('error', 'Unknown error')}")
+            else:
+                console.print("  ℹ️  No files needed processing")
+                
+        except Exception as e:
+            print_error(f"Auto-publish failed: {e}")
+        finally:
+            self.pending_changes.clear()
+
+
+@click.command('publish')
+@click.argument('path', type=click.Path(exists=True), required=False)
+@click.option('--endpoint', '-e', help='SPARQL endpoint URL')
+@click.option('--graph', '-g', help='Named graph URI', type=str)
+@click.option('--username', '-u', help='Username for authentication', type=str)
+@click.option('--password', help='Password for authentication', 
+              type=str, hide_input=True, prompt=False)
+@click.option('--dataset', '-d', help='Dataset name', type=str, default='kb')
+@click.option('--watch', '-w', is_flag=True, help='Watch for changes and auto-publish')
+@click.option('--pattern', multiple=True, help='File patterns to include (e.g., "**/*.md")')
+@click.option('--dry-run', is_flag=True, help='Preview what would be published without publishing')
+@click.option('--force', '-f', is_flag=True, help='Reprocess all files, even if unchanged')
+@click.option('--clear-first', is_flag=True, help='Clear existing data before publishing')
+@click.option('--upsert/--no-upsert', default=True, help='Use upsert to avoid duplicates (default: enabled)')
+@click.option('--batch-size', type=int, default=1000, help='Number of triples per batch')
+@click.option('--debounce', type=float, default=2.0, help='Seconds to wait after file changes before processing')
+@click.pass_obj
+def publish_cmd(ctx, path, endpoint, graph, username, password, dataset, watch, pattern, 
+                dry_run, force, clear_first, upsert, batch_size, debounce):
+    """📤 Publish knowledge base to SPARQL endpoint.
+    
+    Unified workflow that processes documents and syncs them to a SPARQL endpoint
+    in one command. Perfect for both one-shot publishing and continuous publishing
+    during development.
+    
+    \b
+    Examples:
+      kb publish                                  Process + sync with configured endpoint
+      kb publish --endpoint http://localhost:3030/kb  Publish to specific endpoint  
+      kb publish --watch                          Continuous publishing mode
+      kb publish --dry-run                        Preview what would be published
+      kb publish --force                          Reprocess all files
+      kb publish --clear-first                    Replace all existing data
+    """
+    start_time = time.time()
+    
+    console.print(f"\n📤 [heading]Publishing Knowledge Base[/heading]\n")
+    
+    # Determine path
+    publish_path = Path(path).resolve() if path else Path.cwd()
+    
+    # Initialize orchestrator service  
+    orchestrator = OrchestratorService(publish_path)
+    
+    # Check if knowledge base is initialized
+    if not orchestrator.is_initialized():
+        print_error("No knowledge base found. Run 'kb init' first.")
+        return
+    
+    # Get project configuration
+    config = orchestrator.get_project_config()
+    if not config:
+        print_error("Invalid project configuration. Run 'kb init' first.")
+        return
+    
+    # Determine patterns
+    patterns = list(pattern) if pattern else config.file_patterns
+    
+    # Determine endpoint from config if not provided
+    if not endpoint:
+        # Try to load from config
+        endpoint = config.sparql_endpoint
+        if not endpoint:
+            endpoint = "http://localhost:3030/kb"  # Default
+            print_info("Using default endpoint (configure with 'kb config sparql.endpoint <url>')")
+    elif endpoint == "fuseki":
+        endpoint = f"http://localhost:3030/{dataset}"
+        print_info(f"Using Fuseki preset with dataset '{dataset}'")
+    
+    # Determine graph URI from config if not provided
+    if not graph:
+        graph = config.sparql_graph or "http://example.org/knowledgebase"
+        if not config.sparql_graph:
+            print_info("Using default graph URI")
+    
+    # Display configuration
+    print_info(f"Publishing from: {publish_path}")
+    console.print(f"  📋 Patterns: {', '.join(patterns)}")
+    console.print(f"  🎯 Endpoint: [cyan]{endpoint}[/cyan]")
+    if graph:
+        console.print(f"  📊 Graph: [cyan]{graph}[/cyan]")
+    console.print(f"  👤 Authentication: {'Yes' if username else 'No'}")
+    console.print(f"  🔄 Force: {'Yes' if force else 'No'}")
+    console.print(f"  🎯 Upsert mode: {'Enabled' if upsert else 'Disabled'}")
+    
+    if dry_run:
+        console.print("  🔍 [yellow]Dry run mode - no publishing will occur[/yellow]")
+    
+    if clear_first:
+        print_warning("⚠️  Clear-first mode - existing data will be removed!")
+    
+    if not upsert:
+        print_warning("⚠️  Upsert disabled - may create duplicate triples!")
+    
+    console.print()
+    
+    # Setup sync configuration
+    sync_config = {
+        'endpoint_url': endpoint,
+        'graph_uri': graph,
+        'username': username,
+        'password': password,
+        'clear_first': clear_first,
+        'upsert': upsert
+    }
+    
+    # Get authentication if needed
+    if endpoint and username and not password:
+        password = click.prompt('Password', hide_input=True)
+        sync_config['password'] = password
+    
+    def publish_once():
+        """Perform a single publish operation."""
+        try:
+            # Step 1: Process documents
+            console.print("📁 [subheading]Step 1: Processing Documents[/subheading]")
+            
+            doc_count = orchestrator.count_documents(patterns)
+            if doc_count == 0:
+                print_error(f"No files found matching patterns: {', '.join(patterns)}")
+                return False
+            
+            console.print(f"Found {doc_count} files to process")
+            
+            if dry_run:
+                console.print("🔍 Would process files (dry run mode)")
+            else:
+                with create_progress() as progress:
+                    task = progress.add_task("Processing files...", total=doc_count)
+                    
+                    result = orchestrator.process_documents(
+                        patterns=patterns,
+                        force=force
+                    )
+                    
+                    progress.update(task, completed=doc_count)
+                
+                if result.files_processed == 0:
+                    print_info("No files needed processing")
+                    return True
+                
+                console.print(f"  ✅ Processed: {result.files_processed} files")
+                console.print(f"  🔗 Entities: {result.entities_extracted}")
+                console.print(f"  ☐ Todos: {result.todos_found}")
+                
+                if result.files_failed > 0:
+                    console.print(f"  ❌ Errors: {result.files_failed}")
+            
+            # Step 2: Sync to SPARQL
+            console.print("\n🔄 [subheading]Step 2: Syncing to SPARQL[/subheading]")
+            
+            if dry_run:
+                console.print("🔍 Would sync to SPARQL (dry run mode)")
+                return True
+            
+            console.print(f"  🎯 Endpoint: {endpoint}")
+            if graph:
+                console.print(f"  📊 Graph: {graph}")
+            
+            sync_result = orchestrator.sync_to_sparql(**sync_config)
+            
+            if sync_result.get('success'):
+                files_synced = sync_result.get('files_synced', 0)
+                transfer_rate = sync_result.get('transfer_rate', '0 KB/s')
+                sync_time = sync_result.get('sync_time', 0)
+                
+                console.print(f"  ✅ Synced: {files_synced} files")
+                console.print(f"  ⚡ Rate: {transfer_rate}")
+                console.print(f"  ⏱️  Time: {format_duration(sync_time)}")
+                
+                return True
+            else:
+                print_error(f"Sync failed: {sync_result.get('error', 'Unknown error')}")
+                return False
+                
+        except Exception as e:
+            print_error(f"Publishing failed: {e}")
+            if ctx.verbose:
+                console.print_exception()
+            return False
+    
+    # Single publish
+    if not watch:
+        success = publish_once()
+        
+        elapsed = time.time() - start_time
+        
+        if success:
+            print_success(f"Knowledge base published successfully in {format_duration(elapsed)}!")
+            
+            if not dry_run:
+                console.print("\n[subheading]Next steps:[/subheading]")
+                console.print("  • Query your knowledge base via SPARQL endpoint")
+                console.print("  • Use [cyan]kb publish --watch[/cyan] for continuous publishing")
+                console.print("  • Run [cyan]kb status[/cyan] for detailed statistics")
+        else:
+            print_error("Publishing failed")
+        return
+    
+    # Watch mode
+    console.print("👀 [heading]Watch Mode Enabled[/heading]")
+    console.print(f"Monitoring {publish_path} for changes... Press Ctrl+C to stop")
+    console.print(f"Debounce delay: {debounce}s")
+    
+    # Endpoint is already determined from config or provided, so no need to check again
+    
+    # Initial publish
+    console.print("\n🚀 [subheading]Initial Publish[/subheading]")
+    publish_once()
+    
+    # Setup file watching
+    event_handler = KnowledgeBaseHandler(orchestrator, sync_config, debounce)
+    observer = Observer()
+    observer.schedule(event_handler, str(publish_path), recursive=True)
+    
+    try:
+        observer.start()
+        console.print(f"\n✅ Watching for changes in {publish_path}")
+        
+        while True:
+            time.sleep(1)
+            
+            # Check for pending changes to process
+            if event_handler.should_process_changes():
+                event_handler.process_pending_changes()
+                
+    except KeyboardInterrupt:
+        console.print("\n✋ Watch mode stopped")
+        observer.stop()
+    
+    observer.join()

--- a/src/knowledgebase_processor/cli_v2/commands/scan.py
+++ b/src/knowledgebase_processor/cli_v2/commands/scan.py
@@ -13,16 +13,19 @@ from ...services.orchestrator import OrchestratorService
 @click.argument('path', type=click.Path(exists=True), required=False)
 @click.option('--pattern', '-p', multiple=True, help='File patterns to process (e.g., "**/*.md")')
 @click.option('--watch', '-w', is_flag=True, help='Watch for file changes and process automatically')
+@click.option('--sync', is_flag=True, help='Sync to SPARQL after processing')
+@click.option('--endpoint', '-e', help='SPARQL endpoint URL for sync')
 @click.option('--recursive/--no-recursive', '-r/-R', default=True, help='Scan subdirectories')
 @click.option('--force', '-f', is_flag=True, help='Reprocess all files, even if unchanged')
 @click.option('--output', '-o', type=click.Path(), help='Output directory for processed files')
 @click.option('--dry-run', is_flag=True, help='Show what would be processed without actually processing')
 @click.pass_obj
-def scan_cmd(ctx, path, pattern, watch, recursive, force, output, dry_run):
+def scan_cmd(ctx, path, pattern, watch, sync, endpoint, recursive, force, output, dry_run):
     """📁 Scan and process documents.
     
     Processes documents in the specified directory (or current directory)
-    and extracts knowledge entities, todos, and relationships.
+    and extracts knowledge entities, todos, and relationships. Optionally
+    syncs the results to a SPARQL endpoint.
     
     \b
     Examples:
@@ -30,6 +33,7 @@ def scan_cmd(ctx, path, pattern, watch, recursive, force, output, dry_run):
       kb scan ~/Documents              Scan specific directory
       kb scan --pattern "*.md"         Only process Markdown files
       kb scan --watch                  Watch for changes
+      kb scan --sync --endpoint http://localhost:3030/kb  Process + sync to SPARQL
       kb scan --dry-run                Preview what would be processed
     """
     start_time = time.time()
@@ -136,11 +140,41 @@ def scan_cmd(ctx, path, pattern, watch, recursive, force, output, dry_run):
             console.print(f"  🔗 Entities extracted: {result.entities_extracted}")
             console.print(f"  ☐ Todos found: {result.todos_found}")
             
+            # Handle sync if requested
+            if sync:
+                # Determine endpoint from config if not provided
+                sync_endpoint = endpoint
+                if not sync_endpoint:
+                    sync_endpoint = config.sparql_endpoint
+                    if not sync_endpoint:
+                        sync_endpoint = "http://localhost:3030/kb"  # Default
+                        print_info("Using default SPARQL endpoint for sync")
+                
+                console.print("\n🔄 [subheading]Syncing to SPARQL...[/subheading]")
+                console.print(f"  🎯 Endpoint: [cyan]{sync_endpoint}[/cyan]")
+                
+                try:
+                    sync_result = orchestrator.sync_to_sparql(
+                        endpoint_url=sync_endpoint,
+                        upsert=True  # Use upsert by default for scan
+                    )
+                    
+                    if sync_result.get('success'):
+                        files_synced = sync_result.get('files_synced', 0)
+                        transfer_rate = sync_result.get('transfer_rate', '0 KB/s')
+                        console.print(f"  ✅ Synced: {files_synced} files ({transfer_rate})")
+                        print_success("Scan and sync completed successfully!")
+                    else:
+                        print_error(f"Sync failed: {sync_result.get('error', 'Unknown error')}")
+                except Exception as e:
+                    print_error(f"Sync failed: {e}")
+            
             # Show next steps
-            if not watch:
+            if not watch and not sync:
                 console.print("\n[subheading]Next steps:[/subheading]")
                 console.print("  • Use [cyan]kb search[/cyan] to explore your knowledge base")
                 console.print("  • Run [cyan]kb status[/cyan] to see detailed statistics")
+                console.print("  • Add [cyan]--sync --endpoint <url>[/cyan] to publish to SPARQL")
                 console.print("  • Add [cyan]--watch[/cyan] to monitor for file changes")
         else:
             print_error("No files were processed successfully")

--- a/src/knowledgebase_processor/cli_v2/main.py
+++ b/src/knowledgebase_processor/cli_v2/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional
 import sys
 
-from .commands import init, scan, search, sync, status, config
+from .commands import init, scan, search, sync, publish, status, config
 from .utils import console, setup_error_handling
 from .interactive import InteractiveMode
 
@@ -48,13 +48,14 @@ def cli(ctx, version, config, verbose, quiet, no_color, yes):
     Quick Start:
       kb init          Configure processor for your documents
       kb scan          Process documents in current directory  
+      kb publish       Process + sync to SPARQL in one command
       kb search "todo" Search for content
       kb status        Show processing statistics
     
     \b
     Examples:
-      kb scan --watch  Continuously monitor for changes
-      kb sync fuseki   Sync to a SPARQL endpoint
+      kb publish --watch                   Continuous publishing mode
+      kb scan --sync --endpoint <url>      Process + sync to endpoint
       kb search --type todo "project tasks"
     """
     # Create context
@@ -99,6 +100,7 @@ cli.add_command(init.init_cmd)
 cli.add_command(scan.scan_cmd)
 cli.add_command(search.search_cmd)
 cli.add_command(sync.sync_cmd)
+cli.add_command(publish.publish_cmd)
 cli.add_command(status.status_cmd)
 cli.add_command(config.config_cmd)
 


### PR DESCRIPTION
## Summary

This PR introduces a new `kb publish` command that significantly improves the user experience by providing a unified workflow for knowledge base processing and synchronization. The implementation also includes file watching capabilities for automatic updates.

### Key Features

- **🚀 Unified Workflow**: New `kb publish` command combines the two-step process (`kb scan` → `kb sync`) into a single command
- **👁️ File Watching**: `--watch` flag enables automatic file monitoring and synchronization
- **⚖️ Enhanced Scan**: `kb scan` now supports `--sync` option for inline synchronization
- **⚙️ Configuration Integration**: Both commands now properly read SPARQL endpoint from project configuration
- **⏱️ Debounced Processing**: 2-second delay after file changes to prevent excessive operations

### Commands Added/Enhanced

#### New: `kb publish`
```bash
# Publish once
kb publish

# Publish with custom endpoint
kb publish --endpoint http://localhost:3030/mydb

# Watch for changes and auto-publish
kb publish --watch

# Publish to specific graph with upsert
kb publish --graph http://example.org/mygraph --upsert
```

#### Enhanced: `kb scan`
```bash
# Scan and sync in one command
kb scan --sync

# Scan, sync to custom endpoint
kb scan --sync --endpoint http://localhost:3030/mydb
```

### Technical Implementation

- **File Watching**: Uses `watchdog` library for cross-platform file system monitoring
- **Event Handling**: `KnowledgeBaseHandler` class with debouncing logic
- **Configuration**: Consistent endpoint reading from `config.sparql_endpoint`
- **Service Integration**: Leverages existing `OrchestratorService` for business logic
- **Error Handling**: Comprehensive error handling for file operations and sync failures

### Configuration Support

Both commands now respect the project configuration:
```yaml
sparql:
  endpoint: "http://localhost:3030/kb"
```

If no `--endpoint` is provided, commands will:
1. Check project configuration for `sparql.endpoint`
2. Fall back to default: `http://localhost:3030/kb`

### Dependencies

- Added `watchdog ^3.0.0` for file system monitoring

## Test Plan

- [x] Test `kb publish` with default configuration
- [x] Test `kb publish` with custom endpoint
- [x] Test `kb publish --watch` functionality
- [x] Test `kb scan --sync` with configuration
- [x] Verify configuration integration works correctly
- [x] Test file watching with debouncing
- [x] Validate all existing functionality remains intact

## Breaking Changes

None - this is purely additive functionality.

## Migration Guide

Users can immediately start using:
- `kb publish` instead of `kb scan && kb sync`
- `kb publish --watch` for continuous synchronization
- `kb scan --sync` for enhanced scan workflow

Existing workflows continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)